### PR TITLE
ci: change awf sync trigger time

### DIFF
--- a/.github/workflows/sync-awf-upstream.yaml
+++ b/.github/workflows/sync-awf-upstream.yaml
@@ -2,7 +2,7 @@ name: sync-awf-upstream
 
 on:
   schedule:
-    - cron: 0 0 * * *
+    - cron: 0 6 * * *
   workflow_dispatch:
 
 jobs:


### PR DESCRIPTION
## Description

<!-- Write a brief description of this PR. -->
Sync awf autoware_launch upstream before sync [awf autoware.universe upstream](https://github.com/tier4/autoware.universe/blob/tier4/main/.github/workflows/sync-upstream.yaml) leads to fail pilot-auto build.
This is because the former sync is automatic while the latter is manual.
This PR delays the former sync time.

## Tests performed

<!-- Describe how you have tested this PR. -->
<!-- Although the default value is set to "Not Applicable.", please update this section if the type is either [feat, fix, perf], or if requested by the reviewers. -->

Not applicable.

## Pre-review checklist for the PR author

The PR author **must** check the checkboxes below when creating the PR.

- [x] I've confirmed the [contribution guidelines].
- [x] The PR follows the [pull request guidelines].

## In-review checklist for the PR reviewers

The PR reviewers **must** check the checkboxes below before approval.

- [ ] The PR follows the [pull request guidelines].

## Post-review checklist for the PR author

The PR author **must** check the checkboxes below before merging.

- [ ] There are no open discussions or they are tracked via tickets.

After all checkboxes are checked, anyone who has write access can merge the PR.

[contribution guidelines]: https://autowarefoundation.github.io/autoware-documentation/main/contributing/
[pull request guidelines]: https://autowarefoundation.github.io/autoware-documentation/main/contributing/pull-request-guidelines/
