### PR TITLE
perf(elastic_band_smoother): increase lateral replan threshold

### DIFF
--- a/autoware_launch/config/planning/scenario_planning/lane_driving/motion_planning/path_smoother/elastic_band_smoother.param.yaml
+++ b/autoware_launch/config/planning/scenario_planning/lane_driving/motion_planning/path_smoother/elastic_band_smoother.param.yaml
@@ -40,7 +40,7 @@
       enable: true  # if true, only perform smoothing when the input changes significantly
       max_path_shape_around_ego_lat_dist: 2.0  # threshold of path shape change around ego [m]
       max_path_shape_forward_lon_dist: 100.0   # forward point to check lateral distance difference [m]
-      max_path_shape_forward_lat_dist: 0.1     # threshold of path shape change around forward point [m]
+      max_path_shape_forward_lat_dist: 0.2     # threshold of path shape change around forward point [m]
       max_ego_moving_dist: 5.0                 # threshold of ego's moving distance for replan [m]
       # make max_goal_moving_dist long to keep start point fixed for pull over
       max_goal_moving_dist: 15.0               # threshold of goal's moving distance for replan [m]


### PR DESCRIPTION
## Description

<!-- Write a brief description of this PR. -->
Increase the replan lateral distance threshold to prevent costly replanning when the path deviates only a little.

## Tests performed

<!-- Describe how you have tested this PR. -->
<!-- Although the default value is set to "Not Applicable.", please update this section if the type is either [feat, fix, perf], or if requested by the reviewers. -->
Psim

## Effects on system behavior

<!-- Describe how this PR affects the system behavior. -->
The path is not smoothed again if the path changes laterally by less than 0.2m (previously 0.1m).
The path is still smoothed every 1s, regardless of how much it changed.

## Pre-review checklist for the PR author

The PR author **must** check the checkboxes below when creating the PR.

- [X] I've confirmed the [contribution guidelines].
- [X] The PR follows the [pull request guidelines].

## In-review checklist for the PR reviewers

The PR reviewers **must** check the checkboxes below before approval.

- [ ] The PR follows the [pull request guidelines].

## Post-review checklist for the PR author

The PR author **must** check the checkboxes below before merging.

- [ ] There are no open discussions or they are tracked via tickets.

After all checkboxes are checked, anyone who has write access can merge the PR.

[contribution guidelines]: https://autowarefoundation.github.io/autoware-documentation/main/contributing/
[pull request guidelines]: https://autowarefoundation.github.io/autoware-documentation/main/contributing/pull-request-guidelines/
