### PR TITLE
fix(start_planner): check safety only when waiting approval

### DIFF
--- a/autoware_launch/config/planning/scenario_planning/lane_driving/behavior_planning/behavior_path_planner/start_planner/start_planner.param.yaml
+++ b/autoware_launch/config/planning/scenario_planning/lane_driving/behavior_planning/behavior_path_planner/start_planner/start_planner.param.yaml
@@ -84,7 +84,6 @@
         ego_predicted_path:
           min_velocity: 0.0
           min_acceleration: 1.0
-          max_velocity: 1.0
           time_horizon_for_front_object: 10.0
           time_horizon_for_rear_object: 10.0
           time_resolution: 0.5
@@ -138,6 +137,20 @@
           # temporary
           backward_path_length: 30.0
           forward_path_length: 100.0
+
+      surround_moving_obstacle_check:
+          search_radius: 10.0
+          th_moving_obstacle_velocity: 1.0
+          # ObjectTypesToCheck
+          object_types_to_check:
+            check_car: true
+            check_truck: true
+            check_bus: true
+            check_trailer: true
+            check_bicycle: true
+            check_motorcycle: true
+            check_pedestrian: true
+            check_unknown: false
 
       # debug
       debug:


### PR DESCRIPTION
## Description

<!-- Write a brief description of this PR. -->

beta/v0.18.0へのhotfix PR launcher側
以下PRのcherry pick 
https://github.com/autowarefoundation/autoware_launch/pull/723

autoware.universe側のhotfix PR
https://github.com/tier4/autoware.universe/pull/1064

## Tests performed

<!-- Describe how you have tested this PR. -->
<!-- Although the default value is set to "Not Applicable.", please update this section if the type is either [feat, fix, perf], or if requested by the reviewers. -->

Not applicable.

## Effects on system behavior

<!-- Describe how this PR affects the system behavior. -->

Not applicable.

## Pre-review checklist for the PR author

The PR author **must** check the checkboxes below when creating the PR.

- [x] I've confirmed the [contribution guidelines].
- [x] The PR follows the [pull request guidelines].

## In-review checklist for the PR reviewers

The PR reviewers **must** check the checkboxes below before approval.

- [ ] The PR follows the [pull request guidelines].

## Post-review checklist for the PR author

The PR author **must** check the checkboxes below before merging.

- [ ] There are no open discussions or they are tracked via tickets.

After all checkboxes are checked, anyone who has write access can merge the PR.

[contribution guidelines]: https://autowarefoundation.github.io/autoware-documentation/main/contributing/
[pull request guidelines]: https://autowarefoundation.github.io/autoware-documentation/main/contributing/pull-request-guidelines/
