### PR TITLE
feat: use tier4/awf-latest for upstream sync

### DIFF
--- a/.github/workflows/sync-awf-upstream.yaml
+++ b/.github/workflows/sync-awf-upstream.yaml
@@ -44,9 +44,9 @@ jobs:
           token: ${{ steps.generate-token.outputs.token }}
           base-branch: ${{ inputs.target_branch }}
           sync-pr-branch: sync-awf-upstream
-          sync-target-repository: https://github.com/autowarefoundation/autoware_launch.git
-          sync-target-branch: main
-          pr-title: "chore: sync awf/autoware_launch"
+          sync-target-repository: https://github.com/tier4/autoware_launch.git
+          sync-target-branch: awf-latest
+          pr-title: "chore: sync tier4/autoware_launch:awf-latest"
           pr-labels: |
             bot
             sync-awf-upstream


### PR DESCRIPTION
## Description

tier4/pilot-auto:awf-latestのautoware_launchがtier4/autoware_launch:awf-latest (awf/autoware_launch:mainにpilot-auto独自の変更が入れられる) に変わったため、syncのupstream先も変更
https://star4.slack.com/archives/CTEJP8L4T/p1707295696704519
<!-- Write a brief description of this PR. -->

## Tests performed

<!-- Describe how you have tested this PR. -->
<!-- Although the default value is set to "Not Applicable.", please update this section if the type is either [feat, fix, perf], or if requested by the reviewers. -->

Not applicable.

## Effects on system behavior

<!-- Describe how this PR affects the system behavior. -->

Not applicable.

## Pre-review checklist for the PR author

The PR author **must** check the checkboxes below when creating the PR.

- [ ] I've confirmed the [contribution guidelines].
- [ ] The PR follows the [pull request guidelines].

## In-review checklist for the PR reviewers

The PR reviewers **must** check the checkboxes below before approval.

- [ ] The PR follows the [pull request guidelines].

## Post-review checklist for the PR author

The PR author **must** check the checkboxes below before merging.

- [ ] There are no open discussions or they are tracked via tickets.

After all checkboxes are checked, anyone who has write access can merge the PR.

[contribution guidelines]: https://autowarefoundation.github.io/autoware-documentation/main/contributing/
[pull request guidelines]: https://autowarefoundation.github.io/autoware-documentation/main/contributing/pull-request-guidelines/
