### PR TITLE
feat(ci): add sync-tier4-upstream-up-to-tag

### DIFF
--- a/.github/workflows/sync-tier4-upstream-up-to-tag.yaml
+++ b/.github/workflows/sync-tier4-upstream-up-to-tag.yaml
@@ -5,7 +5,7 @@ on:
   workflow_dispatch:
     inputs:
       sync-target-tag:
-        description: "sync target tag like v0.24.0"
+        description: sync target tag like v0.24.0
         required: true
         type: string
         default: ""

--- a/.github/workflows/sync-tier4-upstream-up-to-tag.yaml
+++ b/.github/workflows/sync-tier4-upstream-up-to-tag.yaml
@@ -73,8 +73,8 @@ jobs:
           title: "chore: sync upstream up to ${{ inputs.sync-target-tag }}"
           body: ${{ steps.replace-pr-number-to-url.outputs.changelog }}
           labels: |
-              bot
-              sync-tier4-upstream
+            bot
+            sync-tier4-upstream
           author: github-actions <github-actions@github.com>
           signoff: true
           delete-branch: true

--- a/.github/workflows/sync-tier4-upstream-up-to-tag.yaml
+++ b/.github/workflows/sync-tier4-upstream-up-to-tag.yaml
@@ -1,0 +1,92 @@
+# This workflow is intended for the use in the repositories created by forking tier4/autoware_launch.
+name: sync-tier4-upstream-up-to-tag
+
+on:
+  workflow_dispatch:
+    inputs:
+      sync-target-tag:
+        description: "sync target tag like v0.24.0"
+        required: true
+        type: string
+        default: ""
+
+jobs:
+  sync-tier4-upstream-up-to-tag:
+    runs-on: ubuntu-latest
+    env:
+      BASE_BRANCH: tier4/main
+      SYNC_TARGET_REPOSITORY: https://github.com/tier4/autoware_launch.git
+    steps:
+      - name: Generate token
+        id: generate-token
+        uses: tibdex/github-app-token@v1
+        with:
+          app_id: ${{ secrets.APP_ID }}
+          private_key: ${{ secrets.PRIVATE_KEY }}
+
+      - name: Check out repository
+        uses: actions/checkout@v4
+        with:
+          ref: ${{ env.BASE_BRANCH }}
+          fetch-depth: 0
+
+      - name: Set git config
+        uses: autowarefoundation/autoware-github-actions/set-git-config@v1
+        with:
+          token: ${{ steps.generate-token.outputs.token }}
+
+      - name: Sync tag
+        run: |
+          git remote add sync-target ${{ env.SYNC_TARGET_REPOSITORY }}
+          git fetch -pPtf --all
+          git reset --hard "${{ inputs.sync-target-tag }}"
+          git remote rm sync-target
+        shell: bash
+
+      - name: Generate changelog
+        id: generate-changelog
+        uses: autowarefoundation/autoware-github-actions/generate-changelog@v1
+        with:
+          git-cliff-args: origin/${{ env.BASE_BRANCH }}..HEAD
+
+      - name: Replace PR number to URL
+        id: replace-pr-number-to-url
+        run: |
+          # Output multiline strings: https://docs.github.com/en/actions/using-workflows/workflow-commands-for-github-actions#example-of-a-multiline-string
+          changelog=$(echo "$CHANGELOG" | sed -r "s|\(#([0-9]+)\)|("${REPO_URL%.git}"/pull/\1)|g")
+          EOF=$(dd if=/dev/urandom bs=15 count=1 status=none | base64)
+          echo "changelog<<$EOF" >> $GITHUB_OUTPUT
+          echo "$changelog" >> $GITHUB_OUTPUT
+          echo "$EOF" >> $GITHUB_OUTPUT
+        env:
+          CHANGELOG: ${{ steps.generate-changelog.outputs.changelog }}
+          REPO_URL: ${{ env.SYNC_TARGET_REPOSITORY }}
+        shell: bash
+
+      - name: Create PR
+        id: create-pr
+        uses: peter-evans/create-pull-request@v6
+        with:
+          token: ${{ steps.generate-token.outputs.token }}
+          base: ${{ env.BASE_BRANCH }}
+          branch: sync-tier4-upstream-${{ inputs.sync-target-tag }}
+          title: "chore: sync upstream up to ${{ inputs.sync-target-tag }}"
+          body: ${{ steps.replace-pr-number-to-url.outputs.changelog }}
+          labels: |
+              bot
+              sync-tier4-upstream
+          author: github-actions <github-actions@github.com>
+          signoff: true
+          delete-branch: true
+
+      - name: Check outputs
+        run: |
+          echo "Pull Request Number - ${{ steps.create-pr.outputs.pull-request-number }}"
+          echo "Pull Request URL - ${{ steps.create-pr.outputs.pull-request-url }}"
+
+      - name: Enable auto-merge
+        if: ${{ steps.create-pr.outputs.pull-request-operation == 'created' }}
+        run: gh pr merge --merge --auto "${{ steps.create-pr.outputs.pull-request-number }}"
+        shell: bash
+        env:
+          GITHUB_TOKEN: ${{ steps.generate-token.outputs.token }}


### PR DESCRIPTION
## Description

現行のsync-tier4-upstreamでは、バージョン関係なくtier4/mainに対してsyncを実行してしまうためあるバージョンまでの変更を取り込みたい要望を満たすことが出来ない
そこで、指定したタグまでをsync出来るようにactionを実装した
workflow dispatchとして実行し、その際にsyncしたいバージョンを指定する形を採用した

## Related links

https://tier4.atlassian.net/browse/RT0-30930

## Tests performed
パーソナルリポジトリにて動作を確認した
https://github.com/h-ohta/autoware_launch/actions/runs/8291571585
https://github.com/h-ohta/autoware_launch/pull/13

## Notes for reviewers

<!-- Write additional information if necessary. It should be written if there are related PRs that should be merged at the same time. -->

## Interface changes

<!-- Describe any changed interfaces, such as topics, services, or parameters. -->

## Effects on system behavior

<!-- Describe how this PR affects the system behavior. -->

## Pre-review checklist for the PR author

The PR author **must** check the checkboxes below when creating the PR.

- [ ] I've confirmed the [contribution guidelines].
- [ ] The PR follows the [pull request guidelines].

## In-review checklist for the PR reviewers

The PR reviewers **must** check the checkboxes below before approval.

- [ ] The PR follows the [pull request guidelines].
- [ ] The PR has been properly tested.
- [ ] The PR has been reviewed by the code owners.

## Post-review checklist for the PR author

The PR author **must** check the checkboxes below before merging.

- [ ] There are no open discussions or they are tracked via tickets.
- [ ] The PR is ready for merge.

After all checkboxes are checked, anyone who has write access can merge the PR.

[contribution guidelines]: https://autowarefoundation.github.io/autoware-documentation/main/contributing/
[pull request guidelines]: https://autowarefoundation.github.io/autoware-documentation/main/contributing/pull-request-guidelines/
