### PR TITLE
feat(diagnostic_graph_utils): launch logging node for diagnostic_graph

### DIFF
--- a/autoware_launch/launch/components/tier4_system_component.launch.xml
+++ b/autoware_launch/launch/components/tier4_system_component.launch.xml
@@ -34,4 +34,11 @@
     <arg name="diagnostic_graph_aggregator_param_path" value="$(var diagnostic_graph_aggregator_param_path)"/>
     <arg name="diagnostic_graph_aggregator_graph_path" value="$(var diagnostic_graph_aggregator_graph_path)"/>
   </include>
+
+  <!-- For logging of diagnostics_graph error -->
+  <include file="$(find-pkg-share diagnostic_graph_utils)/launch/logging.launch.xml">
+    <arg name="root_path" value="/autoware/modes/autonomous"/>
+    <arg name="max_depth" value="3"/>
+    <arg name="show_rate" value="0.2"/>
+  </include>
 </launch>


### PR DESCRIPTION
## Description

Launch diagnostic_logging node to display the cause of AUTONOMOUS mode transition failure.

**NODE: This is Pilot.Auto specific modification.**

Need to merge after https://github.com/tier4/autoware.universe/pull/1346

## Tests performed

Run in AWSIM

## Effects on system behavior

The warning message will be displayed when the AUTONOMOUS mode is not available

## Interface changes

None

## Pre-review checklist for the PR author

The PR author **must** check the checkboxes below when creating the PR.

- [x] I've confirmed the [contribution guidelines].
- [x] The PR follows the [pull request guidelines].

## In-review checklist for the PR reviewers

The PR reviewers **must** check the checkboxes below before approval.

- [x] The PR follows the [pull request guidelines].

## Post-review checklist for the PR author

The PR author **must** check the checkboxes below before merging.

- [x] There are no open discussions or they are tracked via tickets.

After all checkboxes are checked, anyone who has write access can merge the PR.

[contribution guidelines]: https://autowarefoundation.github.io/autoware-documentation/main/contributing/
[pull request guidelines]: https://autowarefoundation.github.io/autoware-documentation/main/contributing/pull-request-guidelines/
