### PR TITLE
fix(api): disable rosbridge to fix duplicated node

### DIFF
--- a/autoware_launch/launch/components/tier4_autoware_api_component.launch.xml
+++ b/autoware_launch/launch/components/tier4_autoware_api_component.launch.xml
@@ -2,7 +2,5 @@
 <launch>
   <!-- Fork the repository and add the parameters here if needed. -->
   <arg name="launch_deprecated_api" default="true"/>
-  <arg name="rosbridge_enabled" default="true"/>
-  <arg name="rosbridge_max_message_size" default="1000000000"/>
   <include file="$(find-pkg-share tier4_autoware_api_launch)/launch/autoware_api.launch.xml"/>
 </launch>


### PR DESCRIPTION
## Description

<!-- Write a brief description of this PR. -->

https://github.com/tier4/autoware_launch/pull/496 によりmainとtier4_autoware_api_component.launchを合わせたが/rosbridge_websocketが二重に起動するようになりengaegでできなくなる問題は修正。

fix
```
header:
  stamp:
    sec: 1721364475
    nanosec: 340473583
  frame_id: ''
status:
- level: "\x02"
  name: 'duplicated_node_checker: duplicated_node_checker'
  message: 'Error: Duplicated nodes detected[/rosbridge_websocket], '
  hardware_id: duplicated_node_checker
  values:
  - key: Duplicated Node Name
    value: /rosbridge_websocket
---
```

変更後もfoaは動作することは確認


## Tests performed

<!-- Describe how you have tested this PR. -->
<!-- Although the default value is set to "Not Applicable.", please update this section if the type is either [feat, fix, perf], or if requested by the reviewers. -->

psim with foa

## Effects on system behavior

<!-- Describe how this PR affects the system behavior. -->

Not applicable.

## Interface changes

<!-- Describe any changed interfaces, such as topics, services, or parameters, including debugging interfaces -->

## Pre-review checklist for the PR author

The PR author **must** check the checkboxes below when creating the PR.

- [x] I've confirmed the [contribution guidelines].
- [x] The PR follows the [pull request guidelines].

## In-review checklist for the PR reviewers

The PR reviewers **must** check the checkboxes below before approval.

- [ ] The PR follows the [pull request guidelines].

## Post-review checklist for the PR author

The PR author **must** check the checkboxes below before merging.

- [ ] There are no open discussions or they are tracked via tickets.

After all checkboxes are checked, anyone who has write access can merge the PR.

[contribution guidelines]: https://autowarefoundation.github.io/autoware-documentation/main/contributing/
[pull request guidelines]: https://autowarefoundation.github.io/autoware-documentation/main/contributing/pull-request-guidelines/
