### PR TITLE
revert(api): "fix(api): disable rosbridge to fix duplicated node"

### DIFF
--- a/autoware_launch/launch/components/tier4_autoware_api_component.launch.xml
+++ b/autoware_launch/launch/components/tier4_autoware_api_component.launch.xml
@@ -2,5 +2,7 @@
 <launch>
   <!-- Fork the repository and add the parameters here if needed. -->
   <arg name="launch_deprecated_api" default="true"/>
+  <arg name="rosbridge_enabled" default="true"/>
+  <arg name="rosbridge_max_message_size" default="1000000000"/>
   <include file="$(find-pkg-share tier4_autoware_api_launch)/launch/autoware_api.launch.xml"/>
 </launch>


### PR DESCRIPTION
Reverts tier4/autoware_launch#497

参考：
https://star4.slack.com/archives/CTEJP8L4T/p1722478706445159?thread_ts=1722473867.674629&cid=CTEJP8L4T

tier4/autoware_launch#497 を入れたときには、duplicated_node_checkerによるエラーが出たが、環境起因の問題?と思われるためrevertする