### PR TITLE
feat(lane_change): cherry-pick lane change commits to beta/v0.29.0

### DIFF
--- a/autoware_launch/config/planning/scenario_planning/lane_driving/behavior_planning/behavior_path_planner/lane_change/lane_change.param.yaml
+++ b/autoware_launch/config/planning/scenario_planning/lane_driving/behavior_planning/behavior_path_planner/lane_change/lane_change.param.yaml
@@ -38,6 +38,14 @@
           lateral_distance_max_threshold: 2.0
           longitudinal_distance_min_threshold: 3.0
           longitudinal_velocity_delta_time: 0.8
+        parked:
+          expected_front_deceleration: -1.0
+          expected_rear_deceleration: -2.0
+          rear_vehicle_reaction_time: 1.0
+          rear_vehicle_safety_time_margin: 0.8
+          lateral_distance_max_threshold: 1.0
+          longitudinal_distance_min_threshold: 3.0
+          longitudinal_velocity_delta_time: 0.0
         cancel:
           expected_front_deceleration: -1.0
           expected_rear_deceleration: -2.0

--- a/autoware_launch/config/planning/scenario_planning/lane_driving/behavior_planning/behavior_path_planner/lane_change/lane_change.param.yaml
+++ b/autoware_launch/config/planning/scenario_planning/lane_driving/behavior_planning/behavior_path_planner/lane_change/lane_change.param.yaml
@@ -6,7 +6,6 @@
 
       backward_length_buffer_for_end_of_lane: 3.0 # [m]
       backward_length_buffer_for_blocking_object: 3.0 # [m]
-      lane_change_finish_judge_buffer: 2.0      # [m]
 
       lane_changing_lateral_jerk: 0.5              # [m/s3]
 
@@ -109,7 +108,9 @@
         overhang_tolerance: 0.0             # [m]
         unsafe_hysteresis_threshold: 5      # [/]
 
-      finish_judge_lateral_threshold: 0.2        # [m]
+      lane_change_finish_judge_buffer: 2.0      # [m]
+      finish_judge_lateral_threshold: 0.1        # [m]
+      finish_judge_lateral_angle_deviation: 1.0 # [deg]
 
       # debug
       publish_debug_marker: true

--- a/autoware_launch/config/planning/scenario_planning/lane_driving/behavior_planning/behavior_path_planner/lane_change/lane_change.param.yaml
+++ b/autoware_launch/config/planning/scenario_planning/lane_driving/behavior_planning/behavior_path_planner/lane_change/lane_change.param.yaml
@@ -26,6 +26,11 @@
       min_longitudinal_acc: -1.0
       max_longitudinal_acc: 1.0
 
+      skip_process:
+        longitudinal_distance_diff_threshold:
+          prepare: 1.0
+          lane_changing: 1.0
+
       # safety check
       safety_check:
         allow_loose_check_for_cancel: true


### PR DESCRIPTION
## Description

launcher for https://github.com/tier4/autoware.universe/pull/1441

### ROS Parameter Changes

#### Additions and removals

| Change type   | Parameter Name | Type     | Default Value | Description       |
|:--------------|:---------------|:---------|:--------------|:------------------|
| Added     | `finish_judge_lateral_angle_deviation` | `double` | `1.0`         | lateral angle threshold to determine lane change completion |
| Added     | `parked.expected_front_deceleration` | `double` | `-1.0`         | The front object's maximum deceleration when the front vehicle perform sudden braking |
| Added     | `parked.expected_rear_deceleration` | `double` | `-2.0`         | The rear object's maximum deceleration when the rear vehicle perform sudden braking.  |
| Added     | `parked.rear_vehicle_reaction_time` | `double` | `1.0`         | The reaction time of the rear vehicle driver which starts from the driver noticing the sudden braking of the front vehicle until the driver step on the brake. |
| Added     | `parked.rear_vehicle_safety_time_margin` | `double` | `0.8`         | The time buffer for the rear vehicle to come into complete stop when its driver perform sudden braking. |
| Added     | `parked.lateral_distance_max_threshold` | `double` | `1.0`         | The lateral distance threshold that is used to determine whether lateral distance between two object is enough and whether lane change is safe. |
| Added     | `parked.longitudinal_distance_min_threshold` | `double` | `3.0`         | The longitudinal distance threshold that is used to determine whether longitudinal distance between two object is enough and whether lane change is safe. |
| Added     | `parked.longitudinal_velocity_delta_time` | `double` | `0.0`         | The time multiplier that is used to compute the actual gap between vehicle at each predicted points (not RSS distance) |
| Added     | `skip_process.longitudinal_distance_diff_threshold.prepare` | `double` | `1.0`         | prepare longitudinal distance threshold to skip path planning |
| Added     | `skip_process.longitudinal_distance_diff_threshold.lane_changing` | `double` | `1.0`         | lane changing longitudinal distance threshold to skip path planning |

#### Modifications

| Version | Parameter Name   | Type     | Default Value | Description       |
|:--------|:-----------------|:---------|:--------------|:------------------|
| Old     | `finish_judge_lateral_threshold` | `double` | `0.2`         | lateral threshold to determine lane change completion |
| New     | `finish_judge_lateral_threshold` | `double` | `0.1`         | lateral threshold to determine lane change completion |


## Tests performed

<!-- Describe how you have tested this PR. -->
<!-- Although the default value is set to "Not Applicable.", please update this section if the type is either [feat, fix, perf], or if requested by the reviewers. -->

Not applicable.

## Effects on system behavior

<!-- Describe how this PR affects the system behavior. -->

Not applicable.

## Interface changes

<!-- Describe any changed interfaces, such as topics, services, or parameters, including debugging interfaces -->

## Pre-review checklist for the PR author

The PR author **must** check the checkboxes below when creating the PR.

- [ ] I've confirmed the [contribution guidelines].
- [ ] The PR follows the [pull request guidelines].

## In-review checklist for the PR reviewers

The PR reviewers **must** check the checkboxes below before approval.

- [ ] The PR follows the [pull request guidelines].

## Post-review checklist for the PR author

The PR author **must** check the checkboxes below before merging.

- [ ] There are no open discussions or they are tracked via tickets.

After all checkboxes are checked, anyone who has write access can merge the PR.

[contribution guidelines]: https://autowarefoundation.github.io/autoware-documentation/main/contributing/
[pull request guidelines]: https://autowarefoundation.github.io/autoware-documentation/main/contributing/pull-request-guidelines/
