### PR TITLE
feat(autonomous_emergency_braking): enable AEB by default

### DIFF
--- a/autoware_launch/config/system/diagnostic_graph_aggregator/autoware-psim.yaml
+++ b/autoware_launch/config/system/diagnostic_graph_aggregator/autoware-psim.yaml
@@ -1,5 +1,2 @@
 files:
   - { path: $(find-pkg-share system_diagnostic_monitor)/config/autoware-psim.yaml }
-
-edits:
-  - { type: remove, path: /autoware/control/emergency_braking }

--- a/autoware_launch/launch/components/tier4_control_component.launch.xml
+++ b/autoware_launch/launch/components/tier4_control_component.launch.xml
@@ -4,7 +4,7 @@
   <arg name="lateral_controller_mode" default="mpc"/>
   <arg name="longitudinal_controller_mode" default="pid"/>
   <arg name="use_individual_control_param" default="false"/>
-  <arg name="enable_autonomous_emergency_braking" default="false"/>
+  <arg name="enable_autonomous_emergency_braking" default="true"/>
   <arg name="enable_predicted_path_checker" default="false"/>
 
   <let name="latlon_controller_param_path_dir" value="$(var vehicle_id)" if="$(var use_individual_control_param)"/>


### PR DESCRIPTION
## Description

Enable AEB by default.
The purpose is to always keep the function enabled, allowing us to detect any unnecessary activations caused by malfunctions.

However, as it has not been sufficiently verified that this feature will not cause unnecessary activations, 
**please do not incorporate it into the product code.**

<!-- Write a brief description of this PR. -->

## Tests performed

<!-- Describe how you have tested this PR. -->
<!-- Although the default value is set to "Not Applicable.", please update this section if the type is either [feat, fix, perf], or if requested by the reviewers. -->

- [x] run psim

[Screencast from 2024年10月10日 18時52分47秒.webm](https://github.com/user-attachments/assets/86ae94d9-7aab-4794-a632-5e899d16568a)

- [x] pass [scenarios](https://evaluation.tier4.jp/evaluation/reports/0e9d1dfa-b02c-5f35-9fc8-ff5f9a2ac868?project_id=prd_jt) in autoware evaluator

## Effects on system behavior

<!-- Describe how this PR affects the system behavior. -->

Not applicable.

## Interface changes

<!-- Describe any changed interfaces, such as topics, services, or parameters, including debugging interfaces -->

## Pre-review checklist for the PR author

The PR author **must** check the checkboxes below when creating the PR.

- [x] I've confirmed the [contribution guidelines].
- [x] The PR follows the [pull request guidelines].

## In-review checklist for the PR reviewers

The PR reviewers **must** check the checkboxes below before approval.

- [ ] The PR follows the [pull request guidelines].

## Post-review checklist for the PR author

The PR author **must** check the checkboxes below before merging.

- [ ] There are no open discussions or they are tracked via tickets.

After all checkboxes are checked, anyone who has write access can merge the PR.

[contribution guidelines]: https://autowarefoundation.github.io/autoware-documentation/main/contributing/
[pull request guidelines]: https://autowarefoundation.github.io/autoware-documentation/main/contributing/pull-request-guidelines/
