### PR TITLE
feat(start_planner): set ignore distance from lane end to 0

### DIFF
--- a/autoware_launch/config/planning/scenario_planning/lane_driving/behavior_planning/behavior_path_planner/start_planner/start_planner.param.yaml
+++ b/autoware_launch/config/planning/scenario_planning/lane_driving/behavior_planning/behavior_path_planner/start_planner/start_planner.param.yaml
@@ -50,7 +50,7 @@
       max_back_distance: 20.0
       backward_search_resolution: 2.0
       backward_path_update_duration: 3.0
-      ignore_distance_from_lane_end: 15.0
+      ignore_distance_from_lane_end: 0.0
       # turns signal
       prepare_time_before_start: 0.0
       # freespace planner


### PR DESCRIPTION
…ince it is not needed (#1198)

set param to 0.0 since it is not needed

**Note**: Confirm the [contribution guidelines](https://autowarefoundation.github.io/autoware-documentation/main/contributing/) before submitting a pull request.

Click the `Preview` tab and select a PR template:

- [Standard change](?expand=1&template=standard-change.md)
- [Small change](?expand=1&template=small-change.md)

**Do NOT send a PR with this description.**
