### PR TITLE
revert(diagnostic_graph_aggregeator): revert aeb diag

### DIFF
--- a/autoware_launch/config/system/diagnostic_graph_aggregator/autoware-awsim.yaml
+++ b/autoware_launch/config/system/diagnostic_graph_aggregator/autoware-awsim.yaml
@@ -3,4 +3,3 @@ files:
 
 edits:
   - { type: remove, path: /autoware/system/duplicated_node_checker }
-  - { type: remove, path: /autoware/control/emergency_braking }

--- a/autoware_launch/config/system/diagnostic_graph_aggregator/autoware-main.yaml
+++ b/autoware_launch/config/system/diagnostic_graph_aggregator/autoware-main.yaml
@@ -1,5 +1,2 @@
 files:
   - { path: $(find-pkg-share system_diagnostic_monitor)/config/autoware-main.yaml }
-
-edits:
-  - { type: remove, path: /autoware/control/emergency_braking }


### PR DESCRIPTION
## Description
revert "disable aeb diag check" https://github.com/tier4/autoware_launch/pull/453
<!-- Write a brief description of this PR. -->

part of this issue https://github.com/autowarefoundation/autoware_launch/issues/1221

## Tests performed

<!-- Describe how you have tested this PR. -->
<!-- Although the default value is set to "Not Applicable.", please update this section if the type is either [feat, fix, perf], or if requested by the reviewers. -->

Not applicable.

## Effects on system behavior

<!-- Describe how this PR affects the system behavior. -->

Not applicable.

## Interface changes

<!-- Describe any changed interfaces, such as topics, services, or parameters, including debugging interfaces -->

## Pre-review checklist for the PR author

The PR author **must** check the checkboxes below when creating the PR.

- [ ] I've confirmed the [contribution guidelines].
- [ ] The PR follows the [pull request guidelines].

## In-review checklist for the PR reviewers

The PR reviewers **must** check the checkboxes below before approval.

- [ ] The PR follows the [pull request guidelines].

## Post-review checklist for the PR author

The PR author **must** check the checkboxes below before merging.

- [ ] There are no open discussions or they are tracked via tickets.

After all checkboxes are checked, anyone who has write access can merge the PR.

[contribution guidelines]: https://autowarefoundation.github.io/autoware-documentation/main/contributing/
[pull request guidelines]: https://autowarefoundation.github.io/autoware-documentation/main/contributing/pull-request-guidelines/
