### PR TITLE
feat(autoware_image_projection_based_fusion): make optional to consider lens distortion or not

### DIFF
--- a/autoware_launch/config/perception/object_recognition/detection/image_projection_based_fusion/fusion_common.param.yaml
+++ b/autoware_launch/config/perception/object_recognition/detection/image_projection_based_fusion/fusion_common.param.yaml
@@ -4,6 +4,7 @@
     timeout_ms: 70.0
     match_threshold_ms: 50.0
     image_buffer_size: 15
+    point_project_to_unrectified_image: false
     debug_mode: false
     filter_scope_min_x: -100.0
     filter_scope_min_y: -100.0


### PR DESCRIPTION
## Description

Add an option point_project_to_unrectified_image to switch whether the point project considers lens distortion or not.
cherry-picked from : https://github.com/autowarefoundation/autoware_launch/pull/1207
The tier4/universe needs this:
https://github.com/autowarefoundation/autoware.universe/pull/9233

<!-- Write a brief description of this PR. -->

## Tests performed

<!-- Describe how you have tested this PR. -->
<!-- Although the default value is set to "Not Applicable.", please update this section if the type is either [feat, fix, perf], or if requested by the reviewers. -->

Not applicable.

## Effects on system behavior

<!-- Describe how this PR affects the system behavior. -->

Not applicable.

## Interface changes

<!-- Describe any changed interfaces, such as topics, services, or parameters, including debugging interfaces -->

## Pre-review checklist for the PR author

The PR author **must** check the checkboxes below when creating the PR.

- [ ] I've confirmed the [contribution guidelines].
- [ ] The PR follows the [pull request guidelines].

## In-review checklist for the PR reviewers

The PR reviewers **must** check the checkboxes below before approval.

- [ ] The PR follows the [pull request guidelines].

## Post-review checklist for the PR author

The PR author **must** check the checkboxes below before merging.

- [ ] There are no open discussions or they are tracked via tickets.

After all checkboxes are checked, anyone who has write access can merge the PR.

[contribution guidelines]: https://autowarefoundation.github.io/autoware-documentation/main/contributing/
[pull request guidelines]: https://autowarefoundation.github.io/autoware-documentation/main/contributing/pull-request-guidelines/
