### PR TITLE
feat(system_diagnostic_monitor): enable collision_detector

### DIFF
--- a/autoware_launch/config/system/system_diagnostic_monitor/control.yaml
+++ b/autoware_launch/config/system/system_diagnostic_monitor/control.yaml
@@ -9,6 +9,7 @@ units:
       - { type: link, link: /autoware/control/performance_monitoring/lane_departure }
       - { type: link, link: /autoware/control/performance_monitoring/trajectory_deviation }
       - { type: link, link: /autoware/control/performance_monitoring/control_state }
+      - { type: link, link: /autoware/control/collision_detector}
 
   - path: /autoware/control/local
     type: and
@@ -66,3 +67,8 @@ units:
     type: diag
     node: external_cmd_converter
     name: remote_control_topic_status
+
+  - path: /autoware/control/collision_detector
+    type: diag
+    node: collision_detector
+    name: collision_detect

--- a/autoware_launch/config/system/system_diagnostic_monitor/control.yaml
+++ b/autoware_launch/config/system/system_diagnostic_monitor/control.yaml
@@ -9,7 +9,7 @@ units:
       - { type: link, link: /autoware/control/performance_monitoring/lane_departure }
       - { type: link, link: /autoware/control/performance_monitoring/trajectory_deviation }
       - { type: link, link: /autoware/control/performance_monitoring/control_state }
-      - { type: link, link: /autoware/control/collision_detector}
+      - { type: link, link: /autoware/control/collision_detector }
 
   - path: /autoware/control/local
     type: and

--- a/autoware_launch/launch/components/tier4_control_component.launch.xml
+++ b/autoware_launch/launch/components/tier4_control_component.launch.xml
@@ -6,7 +6,7 @@
   <arg name="use_individual_control_param" default="false"/>
   <arg name="enable_autonomous_emergency_braking" default="true"/>
   <arg name="enable_predicted_path_checker" default="false"/>
-  <arg name="enable_collision_detector" default="false"/>
+  <arg name="enable_collision_detector" default="true"/>
 
   <let name="latlon_controller_param_path_dir" value="$(var vehicle_id)" if="$(var use_individual_control_param)"/>
   <let name="latlon_controller_param_path_dir" value="" unless="$(var use_individual_control_param)"/>


### PR DESCRIPTION
## Description
This PR includes 2 changes
- collision_detector would be on by default
- The system diagnostic monitor would check the diagnostic from collision detector

## Tests performed
- [x] [TIER IV internal evaluator](https://evaluation.tier4.jp/evaluation/reports/a9f7252f-8080-5549-84d3-5274991a2743?project_id=prd_jt)
- [x] PSim (suddenly put a vehicle near to the ego vehicle and check that the MRM is enabled)
```
[mrm_handler_node-23] [INFO] [1730964593.923885985] [system.mrm_handler]: MRM State changed: NORMAL -> MRM_OPERATING
[mrm_handler_node-23] [WARN] [1730964593.924031900] [system.mrm_handler]: MRM behavior is None. Do nothing.
[mrm_handler_node-23] [WARN] [1730964593.924290482] [system.mrm_handler]: EMERGENCY_STOP is operated.
[component_container_mt-39] [WARN] [1730964593.932577759] [control.vehicle_cmd_gate]: Emergency!
[component_container_mt-39] [INFO] [1730964593.972847381] [control.vehicle_cmd_gate]: The operation mode is changed, but the TurnIndicatorsCommand is not received yet:
[component_container_mt-39] [INFO] [1730964594.072510879] [control.vehicle_cmd_gate]: The operation mode is changed, but the TurnIndicatorsCommand is not received yet:
[component_container_mt-39] [INFO] [1730964594.172886994] [control.vehicle_cmd_gate]: The operation mode is changed, but the TurnIndicatorsCommand is not received yet:
[component_container_mt-39] [INFO] [1730964594.272667342] [control.vehicle_cmd_gate]: The operation mode is changed, but the TurnIndicatorsCommand is not received yet:
[logging_node-24] [WARN] [1730964594.337685939] [logging_diag_graph]: The target mode is not available for the following reasons:
[logging_node-24]   - /autoware/modes/autonomous ERROR
[logging_node-24]     - /autoware/control ERROR
[logging_node-24]       - /autoware/control/emergency_braking ERROR
[logging_node-24]       - /autoware/control/collision_detector ERROR
[logging_node-24] 
```
```
[logging_node-24] [WARN] [1730964614.337687076] [logging_diag_graph]: The target mode is not available for the following reasons:
[logging_node-24]   - /autoware/modes/autonomous ERROR
[logging_node-24]     - /autoware/control ERROR
[logging_node-24]       - /autoware/control/collision_detector ERROR
[logging_node-24] 
```


## Effects on system behavior
None

## Interface changes
None

## Pre-review checklist for the PR author

The PR author **must** check the checkboxes below when creating the PR.

- [x] I've confirmed the [contribution guidelines].
- [x] The PR follows the [pull request guidelines].

## In-review checklist for the PR reviewers

The PR reviewers **must** check the checkboxes below before approval.

- [ ] The PR follows the [pull request guidelines].

## Post-review checklist for the PR author

The PR author **must** check the checkboxes below before merging.

- [ ] There are no open discussions or they are tracked via tickets.

After all checkboxes are checked, anyone who has write access can merge the PR.

[contribution guidelines]: https://autowarefoundation.github.io/autoware-documentation/main/contributing/
[pull request guidelines]: https://autowarefoundation.github.io/autoware-documentation/main/contributing/pull-request-guidelines/
