### PR TITLE
feat(aeb): set global param to override autoware state check (#1218)

### DIFF
--- a/autoware_launch/launch/components/tier4_control_component.launch.xml
+++ b/autoware_launch/launch/components/tier4_control_component.launch.xml
@@ -4,6 +4,7 @@
   <arg name="lateral_controller_mode" default="mpc"/>
   <arg name="longitudinal_controller_mode" default="pid"/>
   <arg name="use_individual_control_param" default="false"/>
+  <arg name="use_aeb_autoware_state_check" default="true"/>
   <arg name="enable_autonomous_emergency_braking" default="false"/>
   <arg name="enable_predicted_path_checker" default="false"/>
 
@@ -41,6 +42,7 @@
     <arg name="external_cmd_selector_param_path" value="$(find-pkg-share autoware_launch)/config/control/external_cmd_selector/external_cmd_selector.param.yaml"/>
     <arg name="aeb_param_path" value="$(find-pkg-share autoware_launch)/config/control/autoware_autonomous_emergency_braking/autonomous_emergency_braking.param.yaml"/>
     <arg name="enable_autonomous_emergency_braking" value="$(var enable_autonomous_emergency_braking)"/>
+    <arg name="use_aeb_autoware_state_check" value="$(var use_aeb_autoware_state_check)"/>
     <arg name="enable_predicted_path_checker" value="$(var enable_predicted_path_checker)"/>
     <arg name="predicted_path_checker_param_path" value="$(find-pkg-share autoware_launch)/config/control/predicted_path_checker/predicted_path_checker.param.yaml"/>
   </include>


### PR DESCRIPTION
Cherry-pick of https://github.com/autowarefoundation/autoware_launch/pull/1218 

Mainly used by DLR V2 for planning_control evaluation 
Note, requires universe changes: https://github.com/tier4/autoware.universe/compare/beta/v0.36...tier4:autoware.universe:cherry-pick/add-global-parm-to-disable-aeb-state-check?expand=1

These changes do not affect ego behavior.

* set global param to override autoware state check



* change variable for a more generic name



* set var to false by default



* move param to control component launch



* change param name to be more straightforward



---------

**Note**: Confirm the [contribution guidelines](https://autowarefoundation.github.io/autoware-documentation/main/contributing/) before submitting a pull request.

Click the `Preview` tab and select a PR template:

- [Standard change](?expand=1&template=standard-change.md)
- [Small change](?expand=1&template=small-change.md)

**Do NOT send a PR with this description.**
