### PR TITLE
chore(system_monitor): disable traffic monitor

### DIFF
--- a/autoware_launch/config/system/system_monitor/net_monitor.param.yaml
+++ b/autoware_launch/config/system/system_monitor/net_monitor.param.yaml
@@ -2,7 +2,7 @@
   ros__parameters:
       devices: ["*"]
       monitor_program: "greengrass"
-      enable_traffic_monitor: true
+      enable_traffic_monitor: false
       crc_error_check_duration: 1
       crc_error_count_threshold: 1
       reassembles_failed_check_duration: 1


### PR DESCRIPTION
## Description

launcher change for https://github.com/autowarefoundation/autoware.universe/pull/9069

This PR disables traffic monitor. Traffic monitor is one of modules in system monitor, which measures network traffic by specified programs ( the default target program is `greengrass` ).

The traffic monitor uses `nethogs` to monitor network, but the CPU usage of `nethogs` is high in some systems. This [PR](https://github.com/autowarefoundation/autoware.universe/pull/9069) adds a new config to enable/disable traffic monitor, but the default setting is enabled for OSS Autoware.Universe

For our usage, network traffic by program  is not necessarily collected by default, while  network bandwidth and errors are useful. This PR disables traffic monitor only.

## Tests performed

`nethogs` command doesn't run when enable_traffic_monitor is false

![image](https://github.com/user-attachments/assets/d45f67c0-690c-40c9-9867-358821904dd5)


## Effects on system behavior

<!-- Describe how this PR affects the system behavior. -->

Not applicable.

## Interface changes

None

## Pre-review checklist for the PR author

The PR author **must** check the checkboxes below when creating the PR.

- [x] I've confirmed the [contribution guidelines].
- [x] The PR follows the [pull request guidelines].

## In-review checklist for the PR reviewers

The PR reviewers **must** check the checkboxes below before approval.

- [x] The PR follows the [pull request guidelines].

## Post-review checklist for the PR author

The PR author **must** check the checkboxes below before merging.

- [x] There are no open discussions or they are tracked via tickets.

After all checkboxes are checked, anyone who has write access can merge the PR.

[contribution guidelines]: https://autowarefoundation.github.io/autoware-documentation/main/contributing/
[pull request guidelines]: https://autowarefoundation.github.io/autoware-documentation/main/contributing/pull-request-guidelines/
