### PR TITLE
chore(sync-files.yaml): not synchronize `github-release.yaml`

### DIFF
--- a/.github/sync-files.yaml
+++ b/.github/sync-files.yaml
@@ -12,7 +12,6 @@
     - source: .github/dependabot.yaml
     - source: .github/stale.yml
     - source: .github/workflows/comment-on-pr.yaml
-    - source: .github/workflows/github-release.yaml
     - source: .github/workflows/pre-commit.yaml
     - source: .github/workflows/pre-commit-optional.yaml
     - source: .github/workflows/semantic-pull-request.yaml


### PR DESCRIPTION
## Description

`autoware_launch` version of https://github.com/tier4/autoware.universe/pull/1776

> In the upstream `awf/autoware.universe`, the version control using ROS release tools has started, and tag names different from the current `github-release` workflow are being adopted. However, in this TIER IV fork repository, considering the impact on the product, the `github-release` workflow should remain unchanged. Therefore, this PR removes it from the `sync-files` list.

## Related links

- https://github.com/autowarefoundation/autoware/pull/5652#issuecomment-2606304168

## How was this PR tested?

## Notes for reviewers

None.

## Effects on system behavior

None.
