### PR TITLE
feat: add autoware_ prefix to diagnostic_graph_utils in tier4_system_component.launch.xml

### DIFF
--- a/autoware_launch/launch/components/tier4_system_component.launch.xml
+++ b/autoware_launch/launch/components/tier4_system_component.launch.xml
@@ -30,7 +30,7 @@
   </include>
 
   <!-- For logging of diagnostics_graph error -->
-  <include file="$(find-pkg-share diagnostic_graph_utils)/launch/logging.launch.xml">
+  <include file="$(find-pkg-share autoware_diagnostic_graph_utils)/launch/logging.launch.xml">
     <arg name="root_path" value="/autoware/modes/autonomous"/>
     <arg name="max_depth" value="3"/>
     <arg name="show_rate" value="10.0"/>


### PR DESCRIPTION
## Description
This adds autoware_ prefix to diagnostic_graph_utils package used in tier4_system_component.launch.xml
For the details, please refer to https://github.com/autowarefoundation/autoware.universe/pull/9968

## How was this PR tested?

Made sure that autoware_launch launches correctly:
ros2 launch autoware_launch autoware.launch.xml vehicle_model:=sample_vehicle sensor_model:=aip_xx1 map_path:=/home/mitsudome-r/autoware_map/nishishinjuku_autoware_map/

## Notes for reviewers

Please merge this with https://github.com/autowarefoundation/autoware.universe/pull/9968.

## Effects on system behavior

None.
