### PR TITLE
chore: add a new pr-label "run:build-and-test-differential"

### DIFF
--- a/.github/workflows/sync-awf-latest.yaml
+++ b/.github/workflows/sync-awf-latest.yaml
@@ -27,4 +27,5 @@ jobs:
           pr-title: "chore: sync awf-latest"
           pr-labels: |
             bot
+            run:build-and-test-differential
           auto-merge-method: merge


### PR DESCRIPTION
## Description

Recently, some sync pull requests were not automatically merged. This is because a required label is missing.

So this pull request tries to add the label in `sync-awf-latest.yaml`.

## How was this PR tested?

I cannot test this PR. (A test will be executable when a new commit is added to autowarefoundation/autoware_launch.)

## Notes for reviewers

None.

## Effects on system behavior

None.
