### PR TITLE
chore: fix sync-awf-latest schedule

### DIFF
--- a/.github/workflows/sync-awf-latest.yaml
+++ b/.github/workflows/sync-awf-latest.yaml
@@ -2,7 +2,7 @@ name: sync-awf-latest
 
 on:
   schedule:
-    - cron: 50 */1 * * * # every 1 hour (**:50)
+    - cron: "*/10 * * * *" # every 10 minutes
   workflow_dispatch:
 
 jobs:


### PR DESCRIPTION
## Description

We want to use the latest main for autoware.universe, autoware.core, and autoware_tools.
To match the versions, autoware_launch should be updated more frequently.
So this pull request changes the frequency to trigger the sync-awf-latest action for every 10 minutes.

## How was this PR tested?

We cannot test this change until merging to `tier4/main`.

## Notes for reviewers

None.

## Effects on system behavior

None.
