### PR TITLE
fix(obstacle_cruise_planner): ignore invalid stopping objects

### DIFF
--- a/autoware_launch/config/planning/scenario_planning/lane_driving/motion_planning/motion_velocity_planner/obstacle_cruise.param.yaml
+++ b/autoware_launch/config/planning/scenario_planning/lane_driving/motion_planning/motion_velocity_planner/obstacle_cruise.param.yaml
@@ -95,6 +95,17 @@
             bicycle: false
             pedestrian: false
 
+          # If an object does not have this label, the ego vehicle does not assume that the yielded obstacle will cut in due to the object.
+          side_stopped:
+            unknown: false
+            car: true
+            truck: true
+            bus: true
+            trailer: true
+            motorcycle: true
+            bicycle: false
+            pedestrian: false
+
         max_lat_margin: 1.0 # lateral margin between obstacle and trajectory band with ego's width
 
         # if crossing vehicle is determined as target obstacles or not


### PR DESCRIPTION
## Description

cherry-pick

- https://github.com/autowarefoundation/autoware_launch/pull/1354

Universe PR

- https://github.com/tier4/autoware.universe/pull/1909

## How was this PR tested?

- [ ] Evaluator https://evaluation.tier4.jp/evaluation/reports/40c2e85c-c880-528e-a8a4-c13e74c3847d?project_id=prd_jt
- [x] `planning_simulator` with [sample_map](https://autowarefoundation.github.io/autoware-documentation/main/tutorials/ad-hoc-simulation/planning-simulation/)
- [x] `logging_simulator` with [sample_rosbag](https://autowarefoundation.github.io/autoware-documentation/main/tutorials/ad-hoc-simulation/rosbag-replay-simulation/)
- [x] `logging_simulator` with [awsim_gt_data(TIER IV INTERNAL)](https://drive.google.com/file/d/1BtH3Ry5lu-h85GHM-sYq_jNJLw-s0re6/view?usp=drive_link)
- [x] `e2e_simulator` with [AWSIM v1.3.1](https://github.com/tier4/AWSIM/releases/tag/v1.3.1)

## Notes for reviewers

None.

## Effects on system behavior

None.
