### PR TITLE
fix(sync-files): remove backport.yaml from source

### DIFF
--- a/.github/sync-files.yaml
+++ b/.github/sync-files.yaml
@@ -10,7 +10,6 @@
     - source: .github/ISSUE_TEMPLATE/task.yaml
     - source: .github/pull_request_template.md
     - source: .github/dependabot.yaml
-    - source: .github/workflows/backport.yaml
     - source: .github/stale.yml
     - source: .github/workflows/comment-on-pr.yaml
     - source: .github/workflows/pre-commit.yaml


### PR DESCRIPTION
## Description

Fix `sync-files.yaml` to run sync-file workflow.

## How was this PR tested?

https://github.com/tier4/autoware_launch/actions/runs/13892116504

## Notes for reviewers

None.

## Effects on system behavior

None.
