### PR TITLE
feat(diagnostics): add control diag

### DIFF
--- a/autoware_launch/config/system/tier4_diagnostics/control.yaml
+++ b/autoware_launch/config/system/tier4_diagnostics/control.yaml
@@ -30,8 +30,10 @@ units:
       # - { type: link, link: /control/010-max_distance_deviation-error }
       # - { type: link, link: /control/011-slip_detection }
       - { type: link, link: /control/collision_detector }
+      - { type: link, link: /control/acceleration_error }
       - { type: link, link: /control/rolling_back }
       - { type: link, link: /control/over_velocity }
+      - { type: link, link: /control/overrun_stop_point }
 
   - path: /control/comfortable_stop
     type: and
@@ -130,6 +132,11 @@ units:
     node: collision_detector
     name: collision_detect
 
+  - path: /control/acceleration_error
+    type: diag
+    node: control_validator
+    name: control_validation_acceleration_error
+
   - path: /control/rolling_back
     type: diag
     node: control_validator
@@ -139,3 +146,8 @@ units:
     type: diag
     node: control_validator
     name: control_validation_over_velocity
+
+  - path: /control/overrun_stop_point
+    type: diag
+    node: control_validator
+    name: control_validation_overrun_stop_point


### PR DESCRIPTION
## Description
connect the new control_validator diags to MRM 

https://github.com/autowarefoundation/autoware_universe/pull/10236
https://github.com/autowarefoundation/autoware_universe/pull/10326

## How was this PR tested?
MRM is trigered when the diags are published.
[Screencast from 2025年03月26日 17時24分09秒.webm](https://github.com/user-attachments/assets/1864b151-34a5-4e4a-9e25-b0b514a97dc3)

tier4 scenario test
https://evaluation.tier4.jp/evaluation/reports/eae98895-960f-5841-9981-afebd1a0553a?project_id=prd_jt


## Notes for reviewers

None.

## Effects on system behavior

None.
