### PR TITLE
fix(tier4_diagnostics): remove lane departure trajectory deviation

### DIFF
--- a/autoware_launch/config/system/tier4_diagnostics/control.yaml
+++ b/autoware_launch/config/system/tier4_diagnostics/control.yaml
@@ -25,7 +25,6 @@ units:
     list:
       - { type: link, link: /control/001-topic_status/control_command-error }
       - { type: link, link: /control/004-lane_departure-error }
-      - { type: link, link: /control/005-trajectory_deviation-error }
       - { type: link, link: /control/009-aeb_emergency_stop }
       # - { type: link, link: /control/010-max_distance_deviation-error }
       # - { type: link, link: /control/011-slip_detection }
@@ -61,12 +60,6 @@ units:
       type: link
       link: /control/004-lane_departure
 
-  - path: /control/005-trajectory_deviation-error
-    type: warn-to-ok
-    item:
-      type: link
-      link: /control/005-trajectory_deviation
-
   - path: /control/010-max_distance_deviation-error
     type: warn-to-ok
     item:
@@ -89,12 +82,6 @@ units:
     type: diag
     node: lane_departure_checker_node
     name: lane_departure
-    timeout: 1.0
-
-  - path: /control/005-trajectory_deviation
-    type: diag
-    node: lane_departure_checker_node
-    name: trajectory_deviation
     timeout: 1.0
 
   - path: /control/007-external_command_converter_heartbeat


### PR DESCRIPTION
## Description

Remove lane departure trajectory deviation due to it will no longer being supported by lane departure checker.

## How was this PR tested?

Remove trajectory deviation check from boundary departure checker using the following [PR](https://github.com/autowarefoundation/autoware_universe/pull/10337). Before removing this parameter, autoware cannot engage because of the trajectory deviation error. When this PR is included, we can engage set Autoware to autonomous.

## Notes for reviewers

None.

## Effects on system behavior

None.
