### PR TITLE
feat(tier4_diagnostics): replace overrun estimation diag

### DIFF
--- a/autoware_launch/config/system/tier4_diagnostics/control.yaml
+++ b/autoware_launch/config/system/tier4_diagnostics/control.yaml
@@ -29,10 +29,11 @@ units:
       # - { type: link, link: /control/010-max_distance_deviation-error }
       # - { type: link, link: /control/011-slip_detection }
       - { type: link, link: /control/collision_detector }
-      - { type: link, link: /control/acceleration_error }
+      # - { type: link, link: /control/acceleration_error }
       - { type: link, link: /control/rolling_back }
       - { type: link, link: /control/over_velocity }
       - { type: link, link: /control/overrun_stop_point }
+      - { type: link, link: /control/will_overrun_stop_point }
 
   - path: /control/comfortable_stop
     type: and
@@ -138,3 +139,8 @@ units:
     type: diag
     node: control_validator
     name: control_validation_overrun_stop_point
+
+  - path: /control/will_overrun_stop_point
+    type: diag
+    node: control_validator
+    name: control_validation_will_overrun_stop_point


### PR DESCRIPTION
## Description
Replace `control_validation_acceleration_error` with `control_validation_will_overrun_stop_point`.
The former requires significant per-vehicle adjustments and the latter is less vehicle-dependent.

## How was this PR tested?
tier4 scenario tests
engage available in psim

## Notes for reviewers

None.

## Effects on system behavior

None.
