### PR TITLE
fix: use individual params

### DIFF
--- a/autoware_launch/launch/autoware.launch.xml
+++ b/autoware_launch/launch/autoware.launch.xml
@@ -71,7 +71,7 @@
       <arg name="sensor_model" value="$(var sensor_model)"/>
       <arg name="vehicle_id" value="$(var vehicle_id)"/>
       <arg name="launch_vehicle_interface" value="$(var launch_vehicle_interface)"/>
-      <arg name="config_dir" value="$(find-pkg-share $(var sensor_model)_description)/config"/>
+      <arg name="config_dir" value="$(find-pkg-share individual_params)/config/$(var vehicle_id)/$(var sensor_model)"/>
       <arg name="raw_vehicle_cmd_converter_param_path" value="$(find-pkg-share autoware_launch)/config/vehicle/raw_vehicle_cmd_converter/raw_vehicle_cmd_converter.param.yaml"/>
     </include>
   </group>

--- a/sensor_kit/awsim_labs_sensor_kit_launch/awsim_labs_sensor_kit_launch/launch/imu.launch.xml
+++ b/sensor_kit/awsim_labs_sensor_kit_launch/awsim_labs_sensor_kit_launch/launch/imu.launch.xml
@@ -5,12 +5,14 @@
       <arg name="input_topic" value="tamagawa/imu_raw"/>
       <arg name="output_topic" value="imu_data"/>
       <!-- We are using default node values -->
+      <!-- <arg name="param_file" value="$(find-pkg-share individual_params)/config/$(env VEHICLE_ID default)/awsim_sensor_kit/imu_corrector.param.yaml"/> -->
     </include>
 
     <include file="$(find-pkg-share autoware_imu_corrector)/launch/gyro_bias_estimator.launch.xml">
       <arg name="input_imu_raw" value="tamagawa/imu_raw"/>
       <arg name="input_odom" value="/localization/kinematic_state"/>
       <!-- We are using default node values -->
+      <!-- <arg name="param_file" value="$(find-pkg-share individual_params)/config/$(env VEHICLE_ID default)/awsim_sensor_kit/imu_corrector.param.yaml"/> -->
     </include>
   </group>
 </launch>

--- a/sensor_kit/awsim_sensor_kit_launch/awsim_sensor_kit_launch/launch/imu.launch.xml
+++ b/sensor_kit/awsim_sensor_kit_launch/awsim_sensor_kit_launch/launch/imu.launch.xml
@@ -5,12 +5,14 @@
       <arg name="input_topic" value="tamagawa/imu_raw"/>
       <arg name="output_topic" value="imu_data"/>
       <!-- We are using default node values -->
+      <!-- <arg name="param_file" value="$(find-pkg-share individual_params)/config/$(env VEHICLE_ID default)/awsim_sensor_kit/imu_corrector.param.yaml"/> -->
     </include>
 
     <include file="$(find-pkg-share autoware_imu_corrector)/launch/gyro_bias_estimator.launch.xml">
       <arg name="input_imu_raw" value="tamagawa/imu_raw"/>
       <arg name="input_odom" value="/localization/kinematic_state"/>
       <!-- We are using default node values -->
+      <!-- <arg name="param_file" value="$(find-pkg-share individual_params)/config/$(env VEHICLE_ID default)/awsim_sensor_kit/imu_corrector.param.yaml"/> -->
     </include>
   </group>
 </launch>

--- a/sensor_kit/sample_sensor_kit_launch/sample_sensor_kit_launch/launch/imu.launch.xml
+++ b/sensor_kit/sample_sensor_kit_launch/sample_sensor_kit_launch/launch/imu.launch.xml
@@ -14,7 +14,7 @@
     </group> -->
 
     <arg name="imu_raw_name" default="tamagawa/imu_raw"/>
-    <arg name="imu_corrector_param_file" default="$(find-pkg-share sample_sensor_kit_description)/config/imu_corrector.param.yaml"/>
+    <arg name="imu_corrector_param_file" default="$(find-pkg-share individual_params)/config/$(var vehicle_id)/sample_sensor_kit/imu_corrector.param.yaml"/>
     <include file="$(find-pkg-share autoware_imu_corrector)/launch/imu_corrector.launch.xml">
       <arg name="input_topic" value="$(var imu_raw_name)"/>
       <arg name="output_topic" value="imu_data"/>


### PR DESCRIPTION
## Description

In the PR https://github.com/autowarefoundation/autoware_launch/pull/1403, it removes individual_params dependency.
However, we have to manage individual_params to adapt vehicles, so we revert the change.

## How was this PR tested?

https://evaluation.tier4.jp/evaluation/reports/3eb4aed9-c8b3-5487-b54d-3a79777ab6dd?project_id=prd_jt

## Notes for reviewers

None.

## Effects on system behavior

None.
