### PR TITLE
feat(control_validator, tier4_diagnostics): sync upstream

### DIFF
--- a/autoware_launch/config/control/control_validator/control_validator.param.yaml
+++ b/autoware_launch/config/control/control_validator/control_validator.param.yaml
@@ -9,11 +9,14 @@
 
     thresholds:
       max_distance_deviation: 1.0
+      acc_error_offset: 0.8
+      acc_error_scale: 0.2
       rolling_back_velocity: 0.5
       over_velocity_offset: 2.0
       over_velocity_ratio: 0.2
       overrun_stop_point_dist: 0.8
       nominal_latency: 0.01
 
+    acc_lpf_gain: 0.97 # Time constant 1.11s
     vel_lpf_gain: 0.9 # Time constant 0.33
     hold_velocity_error_until_stop: true

--- a/autoware_launch/config/control/control_validator/control_validator.param.yaml
+++ b/autoware_launch/config/control/control_validator/control_validator.param.yaml
@@ -12,6 +12,7 @@
       rolling_back_velocity: 0.5
       over_velocity_offset: 2.0
       over_velocity_ratio: 0.2
+      overrun_stop_point_dist: 0.8
       nominal_latency: 0.01
 
     vel_lpf_gain: 0.9 # Time constant 0.33

--- a/autoware_launch/config/control/control_validator/control_validator.param.yaml
+++ b/autoware_launch/config/control/control_validator/control_validator.param.yaml
@@ -15,6 +15,9 @@
       over_velocity_offset: 2.0
       over_velocity_ratio: 0.2
       overrun_stop_point_dist: 0.8
+      will_overrun_stop_point_dist: 1.0
+      assumed_limit_acc: 5.0
+      assumed_delay_time: 0.2
       nominal_latency: 0.01
 
     acc_lpf_gain: 0.97 # Time constant 1.11s

--- a/autoware_launch/config/control/control_validator/control_validator.param.yaml
+++ b/autoware_launch/config/control/control_validator/control_validator.param.yaml
@@ -12,6 +12,7 @@
       rolling_back_velocity: 0.5
       over_velocity_offset: 2.0
       over_velocity_ratio: 0.2
+      nominal_latency: 0.01
 
     vel_lpf_gain: 0.9 # Time constant 0.33
     hold_velocity_error_until_stop: true

--- a/autoware_launch/config/system/tier4_diagnostics/control.yaml
+++ b/autoware_launch/config/system/tier4_diagnostics/control.yaml
@@ -29,10 +29,11 @@ units:
       # - { type: link, link: /control/010-max_distance_deviation-error }
       # - { type: link, link: /control/011-slip_detection }
       - { type: link, link: /control/collision_detector }
-      - { type: link, link: /control/acceleration_error }
+      # - { type: link, link: /control/acceleration_error }
       - { type: link, link: /control/rolling_back }
       - { type: link, link: /control/over_velocity }
       - { type: link, link: /control/overrun_stop_point }
+      - { type: link, link: /control/will_overrun_stop_point }
 
   - path: /control/comfortable_stop
     type: and
@@ -138,3 +139,8 @@ units:
     type: diag
     node: control_validator
     name: control_validation_overrun_stop_point
+
+  - path: /control/will_overrun_stop_point
+    type: diag
+    node: control_validator
+    name: control_validation_will_overrun_stop_point

--- a/autoware_launch/config/system/tier4_diagnostics/control.yaml
+++ b/autoware_launch/config/system/tier4_diagnostics/control.yaml
@@ -30,8 +30,10 @@ units:
       # - { type: link, link: /control/010-max_distance_deviation-error }
       # - { type: link, link: /control/011-slip_detection }
       - { type: link, link: /control/collision_detector }
+      - { type: link, link: /control/acceleration_error }
       - { type: link, link: /control/rolling_back }
       - { type: link, link: /control/over_velocity }
+      - { type: link, link: /control/overrun_stop_point }
 
   - path: /control/comfortable_stop
     type: and
@@ -130,6 +132,11 @@ units:
     node: collision_detector
     name: collision_detect
 
+  - path: /control/acceleration_error
+    type: diag
+    node: control_validator
+    name: control_validation_acceleration_error
+
   - path: /control/rolling_back
     type: diag
     node: control_validator
@@ -139,3 +146,8 @@ units:
     type: diag
     node: control_validator
     name: control_validation_over_velocity
+
+  - path: /control/overrun_stop_point
+    type: diag
+    node: control_validator
+    name: control_validation_overrun_stop_point

--- a/autoware_launch/config/system/tier4_diagnostics/control.yaml
+++ b/autoware_launch/config/system/tier4_diagnostics/control.yaml
@@ -25,7 +25,6 @@ units:
     list:
       - { type: link, link: /control/001-topic_status/control_command-error }
       - { type: link, link: /control/004-lane_departure-error }
-      - { type: link, link: /control/005-trajectory_deviation-error }
       - { type: link, link: /control/009-aeb_emergency_stop }
       # - { type: link, link: /control/010-max_distance_deviation-error }
       # - { type: link, link: /control/011-slip_detection }
@@ -61,12 +60,6 @@ units:
       type: link
       link: /control/004-lane_departure
 
-  - path: /control/005-trajectory_deviation-error
-    type: warn-to-ok
-    item:
-      type: link
-      link: /control/005-trajectory_deviation
-
   - path: /control/010-max_distance_deviation-error
     type: warn-to-ok
     item:
@@ -89,12 +82,6 @@ units:
     type: diag
     node: lane_departure_checker_node
     name: lane_departure
-    timeout: 1.0
-
-  - path: /control/005-trajectory_deviation
-    type: diag
-    node: lane_departure_checker_node
-    name: trajectory_deviation
     timeout: 1.0
 
   - path: /control/007-external_command_converter_heartbeat


### PR DESCRIPTION
## Description
beta/v0.41のcontrol_validator関係の設定をv0.41からv0.44相当に更新する変更です。

univese PR: https://github.com/tier4/autoware_universe/pull/1983

## How was this PR tested?
psimにおいて、以下を確認しました。
- /diagnosticsの内容がv0.44相当のものになっていること
- 坂道で走らせても、誤検知が発生しないこと
- シミュレータの車両モデルを意図的壊すとそれらしいMRM停止ができること  

## Notes for reviewers

None.

## Effects on system behavior

None.
