### PR TITLE
chore: update diagnostic_graph_aggregator perception config

### DIFF
--- a/autoware_launch/config/system/tier4_diagnostics/perception.yaml
+++ b/autoware_launch/config/system/tier4_diagnostics/perception.yaml
@@ -82,5 +82,5 @@ units:
   - path: /perception/002-detection_delay
     type: diag
     node: multi_object_tracker
-    name: Perception delay check from original header stamp
+    name: Tracker Timing Diagnostics
     timeout: 1.0


### PR DESCRIPTION
## Description

This PR updates diagnostic_graph_aggregator perception config to sync this [PR](https://github.com/autowarefoundation/autoware_universe/pull/10301) from AWF 

## How was this PR tested?

xx1 tested it on japan taxi 2#. It works fine
Before this update, we will always see an error from `perception/detection-delay-error`
ref: [slack link](https://star4.slack.com/archives/CEV8XMJBV/p1746002119454039?thread_ts=1745551886.798269&cid=CEV8XMJBV) 

## Notes for reviewers

None.

## Effects on system behavior

None.
