### PR TITLE
fix(tier4_perception_launch): add camera ids param for segmentation_pointcloud_fusion

### DIFF
--- a/autoware_launch/launch/components/tier4_perception_component.launch.xml
+++ b/autoware_launch/launch/components/tier4_perception_component.launch.xml
@@ -15,6 +15,7 @@
   <arg name="use_object_filter" default="true" description="launch object filter to filter-out detected object"/>
   <arg name="use_obstacle_segmentation_single_frame_filter" default="false" description="use single frame filter at the ground segmentation"/>
   <arg name="use_obstacle_segmentation_time_series_filter" default="true" description="use time series filter at the ground segmentation"/>
+  <arg name="segmentation_pointcloud_fusion_camera_ids" default="[0,2,4]" description="list of camera ids used for segmentation_pointcloud_fusion node, mainly using front camera"/>
 
   <arg name="occupancy_grid_map_method" default="pointcloud_based" description="options: pointcloud_based, laserscan_based, multi_lidar_pointcloud_based"/>
   <arg name="occupancy_grid_map_updater" default="binary_bayes_filter" description="options: binary_bayes_filter"/>
@@ -57,6 +58,7 @@
     <arg name="objects_validation_method" value="$(var detected_objects_validation_method)"/>
     <arg name="use_obstacle_segmentation_single_frame_filter" value="$(var use_obstacle_segmentation_single_frame_filter)"/>
     <arg name="use_obstacle_segmentation_time_series_filter" value="$(var use_obstacle_segmentation_time_series_filter)"/>
+    <arg name="segmentation_pointcloud_fusion_camera_ids" value="$(var segmentation_pointcloud_fusion_camera_ids)"/>
 
     <!-- traffic light recognition options to switch launch function/module -->
     <arg name="use_traffic_light_recognition" value="$(var use_traffic_light_recognition)"/>


### PR DESCRIPTION
## Description

* cherry-picking of https://github.com/autowarefoundation/autoware_launch/pull/1439

In tier4/pilot-auto, `use_image_segmentation_based_filter` is set to `false` by default, so the problem hasn't surfaced until now.


[TIER IV INTERNAL TICKET](https://tier4.atlassian.net/browse/RT0-36931?linkSource=email)

## How was this PR tested?

## Notes for reviewers

> [!NOTE]
> * This PR should be merged with https://github.com/tier4/autoware_universe/pull/2023

## Effects on system behavior

None.
