### PR TITLE
fix(perception): cherry-pick fixes for perception enhancement

### DIFF
--- a/autoware_launch/config/perception/object_recognition/detection/clustering/voxel_grid_based_euclidean_cluster.param.yaml
+++ b/autoware_launch/config/perception/object_recognition/detection/clustering/voxel_grid_based_euclidean_cluster.param.yaml
@@ -4,7 +4,10 @@
     voxel_leaf_size: 0.3
     min_points_number_per_voxel: 1
     min_cluster_size: 10
-    max_cluster_size: 3000
+    max_cluster_size: 3000 # this is the maximum number of voxels when clustered
+    max_voxel_cluster_for_output: 800  # Maximum number of voxels in a cluster when outputted
+    min_voxel_cluster_size_for_filtering: 65  # Clusters below this number of voxels are exempt from per-voxel filtering
+    max_points_per_voxel_in_large_cluster: 10  # Max points allowed per voxel in a large cluster
     use_height: false
     input_frame: "base_link"
 

--- a/autoware_launch/config/perception/object_recognition/detection/detected_object_validation/object_lanelet_filter.param.yaml
+++ b/autoware_launch/config/perception/object_recognition/detection/detected_object_validation/object_lanelet_filter.param.yaml
@@ -12,15 +12,20 @@
 
     filter_settings:
       # polygon overlap based filter
-      polygon_overlap_filter:
-       enabled: true
+      lanelet_xy_overlap_filter:
+        enabled: true
+
       # velocity direction based filter
       lanelet_direction_filter:
         enabled: false
         velocity_yaw_threshold: 0.785398 # [rad] (45 deg)
         object_speed_threshold: 3.0 # [m/s]
-      debug: false
+
+      # object's elevation from lanelet based filter
+      lanelet_object_elevation_filter:
+        enabled: false
+        max_elevation_threshold: 5.0 # [m] from a lanelet's surface
+        min_elevation_threshold: 0.0 # [m] from a lanelet's surface
+
       lanelet_extra_margin: 0.0
-      use_height_threshold: false
-      max_height_threshold: 10.0 # [m] from the base_link height in map frame
-      min_height_threshold: -1.0 # [m] from the base_link height in map frame
+      debug: false

--- a/autoware_launch/config/perception/object_recognition/detection/object_filter/object_lanelet_filter.param.yaml
+++ b/autoware_launch/config/perception/object_recognition/detection/object_filter/object_lanelet_filter.param.yaml
@@ -12,15 +12,20 @@
 
     filter_settings:
       # polygon overlap based filter
-      polygon_overlap_filter:
+      lanelet_xy_overlap_filter:
         enabled: true
+
       # velocity direction based filter
       lanelet_direction_filter:
         enabled: false
         velocity_yaw_threshold: 0.785398 # [rad] (45 deg)
         object_speed_threshold: 3.0 # [m/s]
-      debug: false
+
+      # object's elevation from lanelet based filter
+      lanelet_object_elevation_filter:
+        enabled: false
+        max_elevation_threshold: 5.0 # [m] from a lanelet's surface
+        min_elevation_threshold: 0.0 # [m] from a lanelet's surface
+
       lanelet_extra_margin: 0.0
-      use_height_threshold: false
-      max_height_threshold: 10.0 # [m] from the base_link height in map frame
-      min_height_threshold: -1.0 # [m] from the base_link height in map frame
+      debug: false

--- a/autoware_launch/config/perception/object_recognition/detection/object_filter/radar_lanelet_filter.param.yaml
+++ b/autoware_launch/config/perception/object_recognition/detection/object_filter/radar_lanelet_filter.param.yaml
@@ -12,15 +12,20 @@
 
     filter_settings:
       # polygon overlap based filter
-      polygon_overlap_filter:
+      lanelet_xy_overlap_filter:
         enabled: true
+
       # velocity direction based filter
       lanelet_direction_filter:
         enabled: false
         velocity_yaw_threshold: 0.785398 # [rad] (45 deg)
         object_speed_threshold: 3.0 # [m/s]
-      debug: false
+
+      # object's elevation from lanelet based filter
+      lanelet_object_elevation_filter:
+        enabled: false
+        max_elevation_threshold: 5.0 # [m] from a lanelet's surface
+        min_elevation_threshold: 0.0 # [m] from a lanelet's surface
+
       lanelet_extra_margin: 0.0
-      use_height_threshold: false
-      max_height_threshold: 10.0 # [m] from the base_link height in map frame
-      min_height_threshold: -1.0 # [m] from the base_link height in map frame
+      debug: false


### PR DESCRIPTION
# Perception Enhancement

## Description
Adds new parameters to control large cluster filtering in the VoxelGridBasedEuclideanCluster implementation. This improves handling of large clusters and optimizes point cloud processing.
Adds 3D filtering to the lanelet filter that will filter objects under the lanelets.


## Changes
- Added `max_voxel_cluster_for_output` parameter
- Removed redundant `max_num_points_per_cluster` parameter
- Updated documentation and tests