### PR TITLE
feat: increase MRM Emergency Stop deceleration

### DIFF
--- a/autoware_launch/config/system/mrm_emergency_stop_operator/mrm_emergency_stop_operator.param.yaml
+++ b/autoware_launch/config/system/mrm_emergency_stop_operator/mrm_emergency_stop_operator.param.yaml
@@ -1,5 +1,5 @@
 /**:
   ros__parameters:
     update_rate: 30
-    target_acceleration: -2.5
+    target_acceleration: -6.0
     target_jerk: -1.5

--- a/autoware_launch/config/system/mrm_emergency_stop_operator/mrm_emergency_stop_operator.param.yaml
+++ b/autoware_launch/config/system/mrm_emergency_stop_operator/mrm_emergency_stop_operator.param.yaml
@@ -2,4 +2,4 @@
   ros__parameters:
     update_rate: 30
     target_acceleration: -6.0
-    target_jerk: -1.5
+    target_jerk: -20.0


### PR DESCRIPTION
## Description

Increased the MRM Emergency Stop decleration from -2.5 to -6.0

## How was this PR tested?

None

## Notes for reviewers

None.

## Effects on system behavior

None.
