### PR TITLE
feat(autoware_multi_object_tracker): unknown as static object (#1481)

### DIFF
--- a/autoware_launch/config/perception/object_recognition/tracking/multi_object_tracker/multi_object_tracker_node.param.yaml
+++ b/autoware_launch/config/perception/object_recognition/tracking/multi_object_tracker/multi_object_tracker_node.param.yaml
@@ -15,12 +15,13 @@
     ego_frame_id: base_link
     enable_delay_compensation: true
     consider_odometry_uncertainty: false
+    enable_unknown_object_velocity_estimation: true
+    enable_unknown_object_motion_output: false
 
     # tracker parameters
     tracker_lifetime: 1.0  # [s]
     min_known_object_removal_iou: 0.1  # [ratio]
     min_unknown_object_removal_iou: 0.001  # [ratio]
-    distance_threshold: 5.0  # [m]
     confident_count_threshold:
       UNKNOWN: 3
       CAR: 3


### PR DESCRIPTION
cherry pick of https://github.com/autowarefoundation/autoware_launch/pull/1481

paired with https://github.com/tier4/autoware_universe/pull/2140



* feat(multi_object_tracker): add parameter to enable unknown object velocity estimation



* feat(multi_object_tracker): enable unknown object velocity estimation by default



* fix(multi_object_tracker): disable unknown object velocity estimation by default



* fix(multi_object_tracker): enable unknown object velocity estimation and disable extrapolation

Updated the multi_object_tracker_node parameters to enable unknown object velocity estimation and disable unknown object extrapolation for improved tracking behavior.



* fix(multi_object_tracker): update parameter for unknown object motion output

Changed the parameter from enable_unknown_object_extrapolation to enable_unknown_object_motion_output to better reflect its purpose in the multi_object_tracker_node configuration.



---------

## Description

## How was this PR tested?

## Notes for reviewers

None.

## Effects on system behavior

None.
