### PR TITLE
fix(autoware_launch): remove redundant lines

### DIFF
--- a/autoware_launch/launch/autoware.launch.xml
+++ b/autoware_launch/launch/autoware.launch.xml
@@ -141,15 +141,6 @@
     </include>
   </group>
 
-  <!-- V2X -->
-  <group if="$(var launch_v2x)">
-    <include file="$(find-pkg-share jpn_signal_launcher)/launch/jpn_signal.launch.xml">
-      <arg name="map_path" value="$(var map_path)"/>
-      <arg name="vehicle_model" value="$(var vehicle_model)"/>
-      <arg name="vehicle_id" value="1"/>
-    </include>
-  </group>
-
   <!-- Tools -->
   <group>
     <node


### PR DESCRIPTION
## Description

Since there were mistaken during the merging in https://github.com/tier4/autoware_launch/pull/942/commits/885037f56fe4dd14721dc17b71949d3cbb4fbd52 of https://github.com/tier4/autoware_launch/pull/942, this PR fixes it.

L135 to L142 is completely the same with L144 to L152.

## How was this PR tested?

## Notes for reviewers

The beta branches were fine.

## Effects on system behavior

None.
