### PR TITLE
fix(perception): enable dynamic map loading in pointcloud_filter 

### DIFF
--- a/autoware_launch/config/perception/object_recognition/detection/pointcloud_filter/pointcloud_map_filter.param.yaml
+++ b/autoware_launch/config/perception/object_recognition/detection/pointcloud_filter/pointcloud_map_filter.param.yaml
@@ -14,7 +14,7 @@
     publish_debug_pcd: False
 
     # use dynamic map loading
-    use_dynamic_map_loading: False
+    use_dynamic_map_loading: True
 
     # time interval to check dynamic map loading
     timer_interval_ms: 100

--- a/autoware_launch/config/perception/object_recognition/detection/pointcloud_filter/pointcloud_map_filter.param.yaml
+++ b/autoware_launch/config/perception/object_recognition/detection/pointcloud_filter/pointcloud_map_filter.param.yaml
@@ -14,7 +14,7 @@
     publish_debug_pcd: False
 
     # use dynamic map loading
-    use_dynamic_map_loading: True
+    use_dynamic_map_loading: true
 
     # time interval to check dynamic map loading
     timer_interval_ms: 100
@@ -26,4 +26,4 @@
     map_loader_radius: 150.0
 
     # Threshold of grid size to split map pointcloud
-    max_map_grid_size: 100.0
+    max_map_grid_size: 1000.0


### PR DESCRIPTION
## Description

When the pointcloud map is very large and the dynamic map load is false, the filter will not work.

https://github.com/autowarefoundation/autoware_launch/issues/1462


## How was this PR tested?

## Notes for reviewers

None.

## Effects on system behavior

None.
