### PR TITLE
feat: update diag settings for control_command_gate (#1332)

### DIFF
--- a/autoware_launch/config/control/control_command_gate/control_command_gate.param.yaml
+++ b/autoware_launch/config/control/control_command_gate/control_command_gate.param.yaml
@@ -1,0 +1,38 @@
+/**:
+  ros__parameters:
+    inputs: [11, 12, 13, 14, 21]  # See autoware_command_mode_types/sources.hpp
+    inputs_names:
+      11: stop
+      12: main
+      13: local
+      14: remote
+      21: emergency_stop
+    rate: 10.0
+    builtin_emergency_acceleration: -2.4
+    stop_hold_acceleration: -1.5
+    emergency_acceleration: -2.4
+    moderate_stop_acceleration: -1.5
+    diag_timeout_warn_duration: 1.0
+    diag_timeout_error_duration: 2.0
+    stop_check_duration: 1.0
+    enable_command_limit_filter: true
+    nominal_filter:
+      vel_lim: 25.0
+      reference_speed_points: [0.1, 0.3, 20.0, 30.0]
+      steer_lim: [1.0, 1.0, 1.0, 0.8]
+      steer_rate_lim: [1.0, 1.0, 1.0, 0.8]
+      lon_acc_lim: [5.0, 5.0, 5.0, 4.0]
+      lon_jerk_lim: [80.0, 5.0, 5.0, 4.0] # The first element is required for quick pedal changes when stopping and starting.
+      lat_acc_lim: [5.0, 5.0, 5.0, 4.0]
+      lat_jerk_lim: [7.0, 7.0, 7.0, 6.0]
+      actual_steer_diff_lim: [1.0, 1.0, 1.0, 0.8]
+    transition_filter:
+      vel_lim: 50.0
+      reference_speed_points: [20.0, 30.0]
+      steer_lim: [1.0, 0.8]
+      steer_rate_lim: [1.0, 0.8]
+      lon_acc_lim: [1.0, 0.9]
+      lon_jerk_lim: [0.5, 0.4]
+      lat_acc_lim: [2.0, 1.8]
+      lat_jerk_lim: [7.0, 6.0]
+      actual_steer_diff_lim: [1.0, 0.8]

--- a/autoware_launch/config/system/command_mode/converter.param.yaml
+++ b/autoware_launch/config/system/command_mode/converter.param.yaml
@@ -1,0 +1,9 @@
+/**:
+  ros__parameters:
+    stop: 1001
+    autonomous: 1002
+    local: 1003
+    remote: 1004
+    emergency_stop: 2001
+    comfortable_stop: 2002
+    pull_over: 2003

--- a/autoware_launch/config/system/command_mode/decider.param.yaml
+++ b/autoware_launch/config/system/command_mode/decider.param.yaml
@@ -1,0 +1,17 @@
+/**:
+  ros__parameters:
+    update_rate: 10.0
+    transition_timeout: 10.0
+    request_timeout: 1.0
+    plugin_name: autoware::command_mode_decider::CommandModeDecider
+    command_modes:  # See autoware_command_mode_types/modes.hpp
+      - 1000  # manual
+      - 1001  # stop
+      - 1002  # autonomous
+      - 1003  # local
+      - 1004  # remote
+      - 2001  # emergency_stop
+      - 2002  # comfortable_stop
+      - 2003  # pull_over
+    initial_operation_mode: 1001
+    initial_autoware_control: true

--- a/autoware_launch/config/system/command_mode/switcher.param.yaml
+++ b/autoware_launch/config/system/command_mode/switcher.param.yaml
@@ -1,0 +1,20 @@
+/**:
+  ros__parameters:
+    update_rate: 10.0
+    multiple_ecu_enabled: false
+    plugins:
+      - autoware::command_mode_switcher::StopSwitcher
+      - autoware::command_mode_switcher::AutonomousSwitcher
+      - autoware::command_mode_switcher::LocalSwitcher
+      - autoware::command_mode_switcher::RemoteSwitcher
+      - autoware::command_mode_switcher::EmergencyStopSwitcher
+      - autoware::command_mode_switcher::ComfortableStopSwitcher
+      - autoware::command_mode_switcher::PullOverSwitcher
+    plugin_parameters:
+      # <plugin name>:  e.g. autoware::command_mode_switcher::StopSwitcher:
+      #   <parameter name>: <value>
+      autoware::command_mode_switcher::ComfortableStopSwitcher:
+        hazard_lights_hz: 20
+        min_acceleration: -1.0
+        max_jerk: 0.6
+        min_jerk: -0.6

--- a/autoware_launch/config/system/diagnostics/control.yaml
+++ b/autoware_launch/config/system/diagnostics/control.yaml
@@ -4,10 +4,16 @@ units:
     list:
       - { type: link, link: /autoware/control/topic_rate_check/trajectory_follower }
       - { type: link, link: /autoware/control/topic_rate_check/control_command }
-      - { type: link, link: /autoware/control/node_alive_monitoring/vehicle_cmd_gate }
+      - { type: link, link: /autoware/control/node_alive_monitoring/command_gate }
       - { type: link, link: /autoware/control/emergency_braking }
       - { type: link, link: /autoware/control/performance_monitoring/lane_departure }
       - { type: link, link: /autoware/control/performance_monitoring/control_state }
+
+  - path: /autoware/control/node_alive_monitoring/command_gate
+    type: or
+    list:
+      - { type: link, link: /autoware/control/node_alive_monitoring/vehicle_cmd_gate }
+      - { type: link, link: /autoware/control/node_alive_monitoring/control_command_gate }
 
   - path: /autoware/control/local
     type: and
@@ -35,6 +41,11 @@ units:
     type: diag
     node: vehicle_cmd_gate
     name: heartbeat
+
+  - path: /autoware/control/node_alive_monitoring/control_command_gate
+    type: diag
+    node: control_command_gate
+    name: timeout_output
 
   - path: /autoware/control/emergency_braking
     type: diag

--- a/autoware_launch/config/system/diagnostics/system.yaml
+++ b/autoware_launch/config/system/diagnostics/system.yaml
@@ -6,6 +6,12 @@ units:
       - { type: link, link: /autoware/system/topic_rate_check/emergency_control_command }
       - { type: link, link: /autoware/system/emergency_stop_operation }
 
+  - path: /autoware/system/emergency_stop_operation
+    type: or
+    list:
+      - { type: link, link: /autoware/system/emergency_stop_operation/vehicle_cmd_gate }
+      - { type: link, link: /autoware/system/emergency_stop_operation/control_command_gate }
+
   - path: /autoware/system/duplicated_node_checker
     type: diag
     node: duplicated_node_checker
@@ -21,7 +27,12 @@ units:
     node: topic_state_monitor_system_emergency_control_cmd
     name: system_topic_status
 
-  - path: /autoware/system/emergency_stop_operation
+  - path: /autoware/system/emergency_stop_operation/vehicle_cmd_gate
     type: diag
     node: vehicle_cmd_gate
     name: emergency_stop_operation
+
+  - path: /autoware/system/emergency_stop_operation/control_command_gate
+    type: diag
+    node: control_command_gate
+    name: timeout_builtin

--- a/autoware_launch/launch/components/tier4_control_component.launch.xml
+++ b/autoware_launch/launch/components/tier4_control_component.launch.xml
@@ -45,6 +45,7 @@
 
     <!-- package param path -->
     <arg name="vehicle_cmd_gate_param_path" value="$(find-pkg-share autoware_launch)/config/control/vehicle_cmd_gate/vehicle_cmd_gate.param.yaml"/>
+    <arg name="control_command_gate_param_path" value="$(find-pkg-share autoware_launch)/config/control/control_command_gate/control_command_gate.param.yaml"/>
     <arg name="lane_departure_checker_param_path" value="$(find-pkg-share autoware_launch)/config/control/lane_departure_checker/lane_departure_checker.param.yaml"/>
     <arg name="control_validator_param_path" value="$(find-pkg-share autoware_launch)/config/control/control_validator/control_validator.param.yaml"/>
     <arg name="operation_mode_transition_manager_param_path" value="$(find-pkg-share autoware_launch)/config/control/operation_mode_transition_manager/operation_mode_transition_manager.param.yaml"/>

--- a/autoware_launch/launch/components/tier4_system_component.launch.xml
+++ b/autoware_launch/launch/components/tier4_system_component.launch.xml
@@ -27,6 +27,9 @@
     <arg name="mrm_handler_param_path" value="$(find-pkg-share autoware_launch)/config/system/mrm_handler/mrm_handler.param.yaml"/>
     <arg name="diagnostic_graph_aggregator_param_path" value="$(var diagnostic_graph_aggregator_param_path)"/>
     <arg name="diagnostic_graph_aggregator_graph_path" value="$(var diagnostic_graph_aggregator_graph_path)"/>
+    <arg name="command_mode_switcher_param_path" value="$(find-pkg-share autoware_launch)/config/system/command_mode/switcher.param.yaml"/>
+    <arg name="command_mode_decider_param_path" value="$(find-pkg-share autoware_launch)/config/system/command_mode/decider.param.yaml"/>
+    <arg name="availability_converter_param_path" value="$(find-pkg-share autoware_launch)/config/system/command_mode/converter.param.yaml"/>
   </include>
 
   <!-- For logging of diagnostics_graph error -->


### PR DESCRIPTION
See https://github.com/autowarefoundation/autoware_launch/pull/1332

The parameter file references and default paths for the control_command_gate and its related nodes have been set up. Additionally, I’ve added the control_command_gate diagnostics to the diag-tree configuration file in a way that doesn’t conflict with the vehicle_cmd_gate’s diag Error.