### PR TITLE
feat(launch): add flag to launch remaining distance calculator

### DIFF
--- a/autoware_launch/config/planning/preset/default_preset.yaml
+++ b/autoware_launch/config/planning/preset/default_preset.yaml
@@ -157,3 +157,8 @@ launch:
   - arg:
       name: launch_rear_collision_checker
       default: "true"
+
+  # other modules
+  - arg:
+      name: launch_remaining_distance_time_calculator
+      default: "true"

--- a/autoware_launch/config/planning/preset/default_preset.yaml
+++ b/autoware_launch/config/planning/preset/default_preset.yaml
@@ -161,4 +161,4 @@ launch:
   # other modules
   - arg:
       name: launch_remaining_distance_time_calculator
-      default: "true"
+      default: "false"


### PR DESCRIPTION
## Description

See original PR
https://github.com/autowarefoundation/autoware_launch/pull/1572

As noted in the related issue, the processing load of `autoware_remaining_distance_time_calculator` is currently extremely high, which may interfere with core components of the autonomous driving system such as Planning and Perception.
To prevent such interference, we are temporarily disabling this module until its performance is improved.

Please consider re-enabling it after the processing load has been optimized.

- https://github.com/autowarefoundation/autoware_universe/issues/11053

## How was this PR tested?

## Notes for reviewers

None.

## Effects on system behavior

None.
