### PR TITLE
feat(intersection_collision_checker): cherry pick #1575

### DIFF
--- a/autoware_launch/config/planning/scenario_planning/common/planning_validator/intersection_collision_checker.param.yaml
+++ b/autoware_launch/config/planning/scenario_planning/common/planning_validator/intersection_collision_checker.param.yaml
@@ -38,6 +38,7 @@
           max_acceleration: 20.0  # [m/s^2]
           max_velocity: 25.0  # [m/s]
           observation_time: 0.3  # [s]
+          max_history_time: 0.5  # [s]
           buffer_size: 10
         latency: 0.3
 


### PR DESCRIPTION
cherry pick of https://github.com/autowarefoundation/autoware_launch/pull/1575
- adds parameter `max_history_time`

required by https://github.com/tier4/autoware_universe/pull/2239
