### PR TITLE
feat(autoware_launch): add traffic light visualization settings in rviz

### DIFF
--- a/autoware_launch/rviz/autoware.rviz
+++ b/autoware_launch/rviz/autoware.rviz
@@ -972,6 +972,43 @@ Visualization Manager:
                 Reliability Policy: Best Effort
                 Value: /perception/traffic_light_recognition/traffic_light_map_based_detector/debug/markers
               Value: true
+            - Class: autoware_perception_rviz_plugin/TrafficLight
+              Enabled: true
+              Lanelet Map Topic: /map/vector_map
+              Name: TrafficLight
+              Show Bulb: true
+              Show Text: false
+              Text Prefix: ""
+              Text X Offset: 0
+              Text Y Offset: 0
+              Text Z Offset: 2.3
+              Traffic Light Topic: /perception/traffic_light_recognition/traffic_signals
+              Value: true
+            - Class: autoware_perception_rviz_plugin/TrafficLight
+              Enabled: false
+              Lanelet Map Topic: /map/vector_map
+              Name: TrafficLight(TLR)
+              Show Bulb: false
+              Show Text: true
+              Text Prefix: "TLR:"
+              Text X Offset: -0.2
+              Text Y Offset: 0
+              Text Z Offset: 1.8
+              Traffic Light Topic: /perception/traffic_light_recognition/internal/traffic_signals
+              Value: true
+            - Class: autoware_perception_rviz_plugin/TrafficLight
+              Enabled: false
+              Font Size: 0.5
+              Lanelet Map Topic: /map/vector_map
+              Name: TrafficLight(V2X)
+              Show Bulb: false
+              Show Text: true
+              Text Prefix: "V2X:"
+              Text X Offset: 0.2
+              Text Y Offset: 0
+              Text Z Offset: 1.3
+              Traffic Light Topic: /v2x/traffic_signals
+              Value: true
           Enabled: true
           Name: TrafficLight
         - Class: rviz_common/Group

--- a/autoware_launch/rviz/planning_bev.rviz
+++ b/autoware_launch/rviz/planning_bev.rviz
@@ -1022,6 +1022,43 @@ Visualization Manager:
                 Reliability Policy: Best Effort
                 Value: /perception/traffic_light_recognition/traffic_light_map_based_detector/debug/markers
               Value: true
+            - Class: autoware_perception_rviz_plugin/TrafficLight
+              Enabled: true
+              Lanelet Map Topic: /map/vector_map
+              Name: TrafficLight
+              Show Bulb: true
+              Show Text: false
+              Text Prefix: ""
+              Text X Offset: 0
+              Text Y Offset: 0
+              Text Z Offset: 2.3
+              Traffic Light Topic: /perception/traffic_light_recognition/traffic_signals
+              Value: true
+            - Class: autoware_perception_rviz_plugin/TrafficLight
+              Enabled: true
+              Lanelet Map Topic: /map/vector_map
+              Name: TrafficLight(TLR)
+              Show Bulb: false
+              Show Text: true
+              Text Prefix: "TLR:"
+              Text X Offset: -0.2
+              Text Y Offset: 0
+              Text Z Offset: 1.8
+              Traffic Light Topic: /perception/traffic_light_recognition/internal/traffic_signals
+              Value: true
+            - Class: autoware_perception_rviz_plugin/TrafficLight
+              Enabled: true
+              Font Size: 0.5
+              Lanelet Map Topic: /map/vector_map
+              Name: TrafficLight(V2X)
+              Show Bulb: false
+              Show Text: true
+              Text Prefix: "V2X:"
+              Text X Offset: 0.2
+              Text Y Offset: 0
+              Text Z Offset: 1.3
+              Traffic Light Topic: /v2x/traffic_signals
+              Value: true
           Enabled: true
           Name: TrafficLight
         - Class: rviz_common/Group

--- a/autoware_launch/rviz/planning_tpv.rviz
+++ b/autoware_launch/rviz/planning_tpv.rviz
@@ -1021,6 +1021,43 @@ Visualization Manager:
                 Reliability Policy: Best Effort
                 Value: /perception/traffic_light_recognition/traffic_light_map_based_detector/debug/markers
               Value: true
+            - Class: autoware_perception_rviz_plugin/TrafficLight
+              Enabled: true
+              Lanelet Map Topic: /map/vector_map
+              Name: TrafficLight
+              Show Bulb: true
+              Show Text: false
+              Text Prefix: ""
+              Text X Offset: 0
+              Text Y Offset: 0
+              Text Z Offset: 2.3
+              Traffic Light Topic: /perception/traffic_light_recognition/traffic_signals
+              Value: true
+            - Class: autoware_perception_rviz_plugin/TrafficLight
+              Enabled: true
+              Lanelet Map Topic: /map/vector_map
+              Name: TrafficLight(TLR)
+              Show Bulb: false
+              Show Text: true
+              Text Prefix: "TLR:"
+              Text X Offset: -0.2
+              Text Y Offset: 0
+              Text Z Offset: 1.8
+              Traffic Light Topic: /perception/traffic_light_recognition/internal/traffic_signals
+              Value: true
+            - Class: autoware_perception_rviz_plugin/TrafficLight
+              Enabled: true
+              Font Size: 0.5
+              Lanelet Map Topic: /map/vector_map
+              Name: TrafficLight(V2X)
+              Show Bulb: false
+              Show Text: true
+              Text Prefix: "V2X:"
+              Text X Offset: 0.2
+              Text Y Offset: 0
+              Text Z Offset: 1.3
+              Traffic Light Topic: /v2x/traffic_signals
+              Value: true              
           Enabled: true
           Name: TrafficLight
         - Class: rviz_common/Group

--- a/autoware_launch/rviz/planning_tpv.rviz
+++ b/autoware_launch/rviz/planning_tpv.rviz
@@ -1057,7 +1057,7 @@ Visualization Manager:
               Text Y Offset: 0
               Text Z Offset: 1.3
               Traffic Light Topic: /v2x/traffic_signals
-              Value: true              
+              Value: true
           Enabled: true
           Name: TrafficLight
         - Class: rviz_common/Group


### PR DESCRIPTION
## Description
This PR enhances the traffic light visualization in RViz by adding three different display modes for traffic signals. It improves the visibility and debugging capabilities of traffic light recognition system by showing both physical traffic lights and their recognition results.

### autoware.rviz

<img width="1212" height="623" alt="image" src="https://github.com/user-attachments/assets/61f73253-9d96-4a0e-b6a9-bfb73512910a" />

### planning_tpv.rviz

<img width="1040" height="493" alt="image" src="https://github.com/user-attachments/assets/2228c071-1330-4e09-82b0-4835684ca140" />

### planning_bev.rviz

<img width="1040" height="493" alt="image" src="https://github.com/user-attachments/assets/f412ef20-942a-483b-ba15-516e5e175ab9" />



### Changes
- Add TrafficLight display configuration to show physical traffic lights with bulb visualization
- Add TrafficLight(TLR) display to show traffic light recognition results with text labels
- Add TrafficLight(V2X) display to show V2X traffic signal information
- Apply these changes to all RViz configuration files:
  - autoware.rviz
  - planning_bev.rviz
  - planning_tpv.rviz

## How was this PR tested?

## Notes for reviewers

None.

## Effects on system behavior

None.
