### PR TITLE
feat: auto beta sync trigger

### DIFF
--- a/.github/workflows/auto-sync-beta-trigger.yaml
+++ b/.github/workflows/auto-sync-beta-trigger.yaml
@@ -1,0 +1,65 @@
+name: auto-sync-beta-trigger
+
+on:
+  pull_request:
+    types:
+      - closed
+    branches:
+      - "beta/v*"
+
+jobs:
+  check-if-merged:
+    runs-on: ubuntu-22.04
+    if: github.event.pull_request.merged == true
+    outputs:
+      beta_version: ${{ steps.extract-version.outputs.beta_version }}
+    steps:
+      - name: Extract beta version
+        id: extract-version
+        run: |
+          BRANCH_NAME="${{ github.event.pull_request.base.ref }}"
+          echo "beta_version=${BRANCH_NAME}" >> $GITHUB_OUTPUT
+
+  sync-beta:
+    needs: check-if-merged
+    runs-on: ubuntu-22.04
+    steps:
+      - name: Generate token
+        id: generate-token
+        uses: actions/create-github-app-token@v1
+        with:
+          app_id: ${{ secrets.APP_ID }}
+          private_key: ${{ secrets.PRIVATE_KEY }}
+          owner: ${{ github.repository_owner }}
+
+      - name: Trigger sync-beta-branches workflow in tier4/autoware-release-scripts
+        uses: benc-uk/workflow-dispatch@v1
+        with:
+          token: ${{ steps.generate-token.outputs.token }}
+          repo: tier4/autoware-release-scripts
+          workflow: sync-beta-branches.yaml
+          ref: main
+          inputs: |
+            {
+              "version": "${{ needs.check-if-merged.outputs.beta_version }}",
+              "product": "vanilla"
+            }
+
+      - name: Comment on PR
+        uses: actions/github-script@v6
+        with:
+          github-token: ${{ steps.generate-token.outputs.token }}
+          script: |
+            const prAuthor = context.payload.pull_request.user.login;
+            const betaVersion = "${{ needs.check-if-merged.outputs.beta_version }}";
+
+            github.rest.issues.createComment({
+              issue_number: context.payload.pull_request.number,
+              owner: context.repo.owner,
+              repo: context.repo.repo,
+              body: `@${prAuthor} - Your PR has been merged to \`${betaVersion}\`.
+
+              The sync-beta-branches workflow has been triggered in the tier4/autoware-release-scripts repository to synchronize the beta branches with version \`${betaVersion}\` for the product.
+
+              Please wait and check .`
+            });

--- a/.github/workflows/auto-sync-beta-trigger.yaml
+++ b/.github/workflows/auto-sync-beta-trigger.yaml
@@ -5,7 +5,7 @@ on:
     types:
       - closed
     branches:
-      - "beta/v*"
+      - beta/v*
 
 jobs:
   check-if-merged:

--- a/.github/workflows/auto-sync-beta-trigger.yaml
+++ b/.github/workflows/auto-sync-beta-trigger.yaml
@@ -37,10 +37,11 @@ jobs:
         with:
           token: ${{ steps.generate-token.outputs.token }}
           repo: tier4/autoware-release-scripts
-          workflow: sync-beta-branches.yaml
+          workflow: branch-manager-runner.yaml
           ref: main
           inputs: |
             {
+              "script_type": "sync_branches",
               "version": "${{ needs.check-if-merged.outputs.beta_version }}",
               "product": "vanilla"
             }


### PR DESCRIPTION
## Description

This is a new feature that I would like to test.

Whenever a PR is merged on the beta/X.Y, it will trigger the sync-beta-branches action on the release system.

- version is the current version here.
- The product name needs to be defined by different teams.
- Hope to apply in vanilla, but let's first test everything here.


Test:
https://github.com/tier4/truck_description/pull/15/

XX1: example
https://github.com/tier4/autoware_launch.xx1/pull/1486

## How was this PR tested?

## Notes for reviewers

None.

## Effects on system behavior

None.
