### PR TITLE
feat: change planning output topic name to /planning/trajectory

### DIFF
--- a/autoware_launch/rviz/autoware_debug.rviz
+++ b/autoware_launch/rviz/autoware_debug.rviz
@@ -1042,7 +1042,7 @@ Visualization Manager:
                 Filter size: 10
                 History Policy: Keep Last
                 Reliability Policy: Reliable
-                Value: /planning/scenario_planning/trajectory
+                Value: /planning/trajectory
               Value: true
               View Footprint:
                 Alpha: 1


### PR DESCRIPTION
## Description
This changes the topic name for `/planning/scenario_planning/trajectory` to `/planning/trajectory` as part of https://github.com/autowarefoundation/autoware/issues/6292.

This only updates autoware_debug.rviz plugin since the rest is updated in https://github.com/autowarefoundation/autoware_launch/pull/1594

This must be merged after:
 - https://github.com/autowarefoundation/autoware_launch/pull/1594
 - https://github.com/autowarefoundation/autoware_core/pull/602
 - https://github.com/autowarefoundation/autoware_universe/pull/11135
 - https://github.com/tier4/tier4_ad_api_adaptor/pull/169

## Related links
https://github.com/autowarefoundation/autoware/issues/6292
https://github.com/autowarefoundation/autoware/issues/6292#issuecomment-3166352528

## How was this PR tested?

## Notes for reviewers

None.

## Effects on system behavior

None.
