### PR TITLE
feat(boundary_departure): on time buffer for critical departure (#1591)

### DIFF
--- a/autoware_launch/config/planning/scenario_planning/lane_driving/motion_planning/motion_velocity_planner/boundary_departure_prevention.param.yaml
+++ b/autoware_launch/config/planning/scenario_planning/lane_driving/motion_planning/motion_velocity_planner/boundary_departure_prevention.param.yaml
@@ -14,7 +14,9 @@
         near_boundary: 3.5
         departure: 2.0
 
-      on_time_buffer_s: 0.15
+      on_time_buffer_s:
+        near_boundary: 0.15
+        critical_departure: 0.15
       off_time_buffer_s: 0.15
 
       abnormality:


### PR DESCRIPTION
## Description

Add `on_time_buffer` for `critical_departure`. 
The parameter works as hysteresis for accepting critical departure point.

https://github.com/tier4/autoware_universe/pull/2301

#### Additions and removals

| Change type   | Parameter Name | Type     | Default Value | Description       |
|:--------------|:---------------|:---------|:--------------|:------------------|
| Added | `on_time_buffer_s.critical_departure`   | `double` | `0.15`         | Continuous detection time required to accept new critical departure point. [s] |

#### Modifications

| Version | Parameter Name   | Type     | Default Value | Description       |
|:--------|:-----------------|:---------|:--------------|:------------------|
| Old     | `on_time_buffer_s` | `double` | `0.15`         | Continuous detection time threshold to insert departure point into departure interval. [s] |
| New     | `on_time_buffer_s.near_boundary` | `double` | `0.15`         | Continuous detection time threshold to insert departure point into departure interval. [s] |

## How was this PR tested?

## Notes for reviewers

None.

## Effects on system behavior

None.
