### PR TITLE
feat(planning_validator): disable soft stop for trajectory shift feature

### DIFF
--- a/autoware_launch/config/planning/scenario_planning/common/planning_validator/trajectory_checker.param.yaml
+++ b/autoware_launch/config/planning/scenario_planning/common/planning_validator/trajectory_checker.param.yaml
@@ -50,5 +50,5 @@
         lat_shift_th: 0.5
         forward_shift_th: 1.0
         backward_shift_th: 0.1
-        handling_type: 2  # handling types are defined in common planning validator parameters
+        handling_type: 1  # handling types are defined in common planning validator parameters
         override_error_diag: false

--- a/autoware_launch/config/system/tier4_diagnostics/planning.yaml
+++ b/autoware_launch/config/system/tier4_diagnostics/planning.yaml
@@ -35,7 +35,7 @@ units:
       - { type: link, link: /planning/010-trajectory_steering_validation-error }
       - { type: link, link: /planning/011-trajectory_steering_rate_validation-error }
       - { type: link, link: /planning/012-trajectory_velocity_deviation_validation-error }
-      # - { type: link, link: /planning/013-trajectory_shift_validation-error }
+      - { type: link, link: /planning/013-trajectory_shift_validation-error }
       # - { type: link, link: /planning/014-intersection_collision_checker-error }
       # - { type: link, link: /planning/015-collision_checker-error }
       - { type: link, link: /planning/016-path_optimizer_emergency_stop-error }


### PR DESCRIPTION
## Description

Previously, the keeping valid path before abnomaly detection and the velocity embedding after deceleration application were performed within the planning_validator. 
However, since this could result in speed plans that the vehicle cannot follow, change the approach so that the planning_validator handles the process up to keeping last valid path and error level diagnostic output, while the subsequent deceleration behavior will be handled by the MRM side.

| Before | After |
| ------ | ----- |
| <video src="https://github.com/user-attachments/assets/866992b7-8785-4ef4-a7a1-ca97ee3d1f1a" controls width="400"></video> | <video src="https://github.com/user-attachments/assets/8dbd17f9-426c-4424-accf-e415808bec46" controls width="400"></video> |

## How was this PR tested?

- [x] Intentionally trigger route deviation in manual driving mode to confirm that diag error level becomes error before changes and does not become error after changes.
- [x] PASS TIERIV INTERNAL SCENARIOS
  - [x] https://evaluation.tier4.jp/evaluation/oidc/auth/cb/?code=ory_ac__uOYxxKpE65M7MI1vCd5hXkUHOOyf9xUcHyn9-XSF5M.zzZDkTSIcgDm_Sve7QS-jmuhn0smm6VLN3CJWav5yl8&scope=openid+profile+email+offline_access&state=32b794a195a34f6cb0a727a0946aa910
  - [x] https://evaluation.tier4.jp/evaluation/reports/ef55b2e4-083f-53a7-9a6f-aa1c635e4adc?project_id=prd_jt
  - [x] https://evaluation.tier4.jp/evaluation/reports/a5a847c3-3580-5885-a075-120a39d3a9ec?project_id=prd_jt

## Notes for reviewers

None.

## Effects on system behavior

None.
