### PR TITLE
feat(tracker): adjust generalized IoU threshold based on target object speed

### DIFF
--- a/autoware_launch/config/perception/object_recognition/tracking/multi_object_tracker/multi_object_tracker_node.param.yaml
+++ b/autoware_launch/config/perception/object_recognition/tracking/multi_object_tracker/multi_object_tracker_node.param.yaml
@@ -28,6 +28,9 @@
     pruning_generalized_iou_thresholds:
       # UNKNOWN,  CAR, TRUCK,  BUS, TRAILER, MOTORCYCLE, BICYCLE, PEDESTRIAN
       [    -0.3, -0.4,  -0.6, -0.6,    -0.6,       -0.1,    -0.1,       -0.1]
+    pruning_static_object_speed: 1.38  # [m/s]
+    pruning_moving_object_speed: 5.5   # [m/s]
+    pruning_static_iou_threshold: 0.0  # [ratio]
     pruning_distance_thresholds:
       # UNKNOWN, CAR, TRUCK, BUS, TRAILER, MOTORCYCLE, BICYCLE, PEDESTRIAN
       [     9.0, 5.0,   9.0, 9.0,     9.0,        4.0,     3.0,        2.0]


### PR DESCRIPTION

Need to merge with https://github.com/tier4/autoware_universe/pull/2323
Cherry-pick #1615


## Description

This pull request enhances the logic for merging overlapped trackers in the multi-object tracker by introducing a dynamic threshold for the generalized IoU metric that adapts based on the speed of the tracked object. This change aims to improve the accuracy of tracker pruning, especially for objects with unknown classifications, by making the overlap criteria more sensitive to object motion.

## How was this PR tested?

## Notes for reviewers

None.

## Effects on system behavior

None.
