### PR TITLE
revert(obstacle_stop): disable opposing traffic feature (#1626)

### DIFF
--- a/autoware_launch/config/planning/scenario_planning/lane_driving/motion_planning/motion_velocity_planner/obstacle_stop.param.yaml
+++ b/autoware_launch/config/planning/scenario_planning/lane_driving/motion_planning/motion_velocity_planner/obstacle_stop.param.yaml
@@ -10,7 +10,7 @@
         terminal_stop_margin : 3.0 # Stop margin at the goal. This value cannot exceed stop margin. [m]
         min_behavior_stop_margin: 3.0 # [m]
 
-        max_negative_velocity: -1.0 # [m/s] maximum velocity of opposing traffic to consider stop planning
+        max_negative_velocity: -100.0 # [m/s] maximum velocity of opposing traffic to consider stop planning
         stop_margin_opposing_traffic: 10.0 # Ideal stop-margin from moving opposing obstacle when ego comes to a stop
         effective_deceleration_opposing_traffic: 4.0 # Setting a higher value brings the final stop-margin closer to the ideal value above
 


### PR DESCRIPTION
対向車両に対する手前での停止機能について、開発中の機能であり、問題が複数見られるので、機能を無効化します。
