### PR TITLE
fix(hdd_monitor,cpu_monitor): use unix sockets for IPC with helper applications

### DIFF
--- a/autoware_launch/config/system/system_monitor/cpu_monitor.param.yaml
+++ b/autoware_launch/config/system/system_monitor/cpu_monitor.param.yaml
@@ -5,4 +5,4 @@
     usage_warn_count: 1
     usage_error_count: 2
     usage_avg: true
-    msr_reader_port: 7634
+    msr_reader_socket_path: "/tmp/msr_reader.sock"

--- a/autoware_launch/config/system/system_monitor/hdd_monitor.param.yaml
+++ b/autoware_launch/config/system/system_monitor/hdd_monitor.param.yaml
@@ -1,6 +1,6 @@
 /**:
   ros__parameters:
-    hdd_reader_port: 7635
+    hdd_reader_socket_path: "/tmp/hdd_reader.sock"
     num_disks: 1
     disks: # Until multi type lists are allowed, name N the disks as disk0...disk{N-1}
       disk0:


### PR DESCRIPTION
This PR is a cherry-picking PR which backports the following PR to tier4/autoware_universe.
- https://github.com/autowarefoundation/autoware_launch/pull/1628

Changes in this PR:
- Replace IPC port numbers with AF_UNIX domain socket names for cpu_monitor and hdd_monitor.

**NOTE:**
The related cherry-picking PR to the "autoware_universe" repository (https://github.com/tier4/autoware_universe/pull/2366) should be merged simultaneously with this PR.