### PR TITLE
feat(obstcle_stop, obstacle_slow_down): dissable opposite traffic feature, add cruve additional margin feature

### DIFF
--- a/autoware_launch/config/planning/scenario_planning/lane_driving/motion_planning/motion_velocity_planner/obstacle_slow_down.param.yaml
+++ b/autoware_launch/config/planning/scenario_planning/lane_driving/motion_planning/motion_velocity_planner/obstacle_slow_down.param.yaml
@@ -36,6 +36,7 @@
                 max_lat_margin: 1.0
                 min_ego_velocity: 4.0
                 max_ego_velocity: 8.0
+            wheel_off_track_scale: 0.0 # scale factor for additional stop margin against ego's wheel off-track. Even if this value is set to 0.0, the planner considers the nominal wheel off-track.
           # car.left.moving.min_ego_velocity: 3.0  # example specific override
 
         moving_object_speed_threshold: 0.5 # [m/s] how fast the object needs to move to be considered as "moving"
@@ -53,7 +54,10 @@
           pedestrian: true
           pointcloud: false
 
-        min_lat_margin: 0.0  # lateral margin between obstacle and trajectory band with ego's width to avoid the conflict with the obstacle_stop
+        # Previously and ideally, the min_lat_margin was 0.
+        # However, the objects whose lateral margin is between 0 and 'wheel_off_track_scale times wheel_off_track' are ignored by the obstacle_slow_down module unexpectedly due to the current implementation.
+        # Therefore, we set the min_lat_margin to a large negative value temporarily.
+        min_lat_margin: -10.0  # lateral margin between obstacle and trajectory band with ego's width to avoid the conflict with the obstacle_stop
         max_lat_margin: 1.1  # lateral margin between obstacle and trajectory band with ego's width
         lat_hysteresis_margin: 0.2
 


### PR DESCRIPTION
## Description
- obstacle_slow_downにカーブで追加の横マージンを設ける機能を追加

core: https://github.com/tier4/autoware_core/pull/46
universe: https://github.com/tier4/autoware_universe/pull/2379

## How was this PR tested?
psimでエンゲージできるところまで

## Notes for reviewers

None.

## Effects on system behavior

None.
