### PR TITLE
chore(pose_instability_detector): relieve vertical tolerance threshold

### DIFF
--- a/autoware_launch/config/localization/pose_instability_detector.param.yaml
+++ b/autoware_launch/config/localization/pose_instability_detector.param.yaml
@@ -11,7 +11,7 @@
 
     pose_estimator_longitudinal_tolerance: 0.11   # [m]
     pose_estimator_lateral_tolerance: 0.11        # [m]
-    pose_estimator_vertical_tolerance: 0.11       # [m]
+    pose_estimator_vertical_tolerance: 0.5        # [m]
     pose_estimator_angular_tolerance: 0.0175      # [rad]
 
     enable_validation:


### PR DESCRIPTION
## Description

Cherry-Pick of https://github.com/autowarefoundation/autoware_launch/pull/1667

The pose_instability_detector detects position jump of vehicles and its threshold is calculated based on the parameters.

The parameter `pose_estimator_vertical_tolerance` manages the jump of the z coordinates but the current default value `0.11` is too small when we consider bumpy roads. This PR relieves it to `0.5` meters.

## How was this PR tested?

Checked that `ros2 param dump` outputs the revised parameter.
<img width="602" height="861" alt="Screenshot from 2025-10-08 16-07-25" src="https://github.com/user-attachments/assets/24e8d39c-2d18-42d0-b21a-ebfa072ecdbb" />


The `rqt_runtime_monitor` shows the `position_z` threshold based on the new parameter.
<img width="1442" height="1439" alt="image" src="https://github.com/user-attachments/assets/fbcee035-5806-425a-9ebd-03d970a593db" />

## Effects on system behavior

The pose_instability_detector diagnostics will be more tolerant to shaky vehicle positions in the z coordinate.
