### PR TITLE
feat(obstacle_slow_down, obstacle_stop): sync code update

### DIFF
--- a/autoware_launch/config/planning/scenario_planning/lane_driving/motion_planning/motion_velocity_planner/obstacle_slow_down.param.yaml
+++ b/autoware_launch/config/planning/scenario_planning/lane_driving/motion_planning/motion_velocity_planner/obstacle_slow_down.param.yaml
@@ -5,8 +5,8 @@
         slow_down_min_acc: -1.0         # slow down min deceleration [m/ss]
         slow_down_min_jerk: -1.0        # slow down min jerk [m/sss]
 
-        lpf_gain_slow_down_vel: 0.99 # low-pass filter gain for slow down velocity
-        lpf_gain_lat_dist: 0.999 # low-pass filter gain for lateral distance from obstacle to ego's path
+        lpf_gain_slow_down_vel: 0.9 # low-pass filter gain for slow down velocity
+        lpf_gain_lateral_distance: 0.7 # low-pass filter gain for lateral distance from obstacle to ego's path
         lpf_gain_dist_to_slow_down: 0.7 # low-pass filter gain for distance to slow down start
 
         time_margin_on_target_velocity: 1.5 # [s]

--- a/autoware_launch/config/planning/scenario_planning/lane_driving/motion_planning/motion_velocity_planner/obstacle_slow_down.param.yaml
+++ b/autoware_launch/config/planning/scenario_planning/lane_driving/motion_planning/motion_velocity_planner/obstacle_slow_down.param.yaml
@@ -60,6 +60,7 @@
         min_lat_margin: -10.0  # lateral margin between obstacle and trajectory band with ego's width to avoid the conflict with the obstacle_stop
         max_lat_margin: 1.1  # lateral margin between obstacle and trajectory band with ego's width
         lat_hysteresis_margin: 0.2
+        max_lat_velocity: 3.0 # [m/s] max lateral velocity of obstacle to be considered
 
         successive_num_to_entry_slow_down_condition: 5
         successive_num_to_exit_slow_down_condition: 5

--- a/autoware_launch/config/planning/scenario_planning/lane_driving/motion_planning/motion_velocity_planner/obstacle_stop.param.yaml
+++ b/autoware_launch/config/planning/scenario_planning/lane_driving/motion_planning/motion_velocity_planner/obstacle_stop.param.yaml
@@ -9,6 +9,7 @@
         stop_margin : 5.0 # longitudinal margin to obstacle [m]
         terminal_stop_margin : 3.0 # Stop margin at the goal. This value cannot exceed stop margin. [m]
         min_behavior_stop_margin: 3.0 # [m]
+        behavior_stop_margin_hold_time: 2.0 # [s] time to hold the min_behavior_stop_margin after disappearing the behavior stop point
 
         max_negative_velocity: -100.0 # [m/s] maximum velocity of opposing traffic to consider stop planning
         stop_margin_opposing_traffic: 10.0 # Ideal stop-margin from moving opposing obstacle when ego comes to a stop

--- a/autoware_launch/config/planning/scenario_planning/lane_driving/motion_planning/motion_velocity_planner/obstacle_stop.param.yaml
+++ b/autoware_launch/config/planning/scenario_planning/lane_driving/motion_planning/motion_velocity_planner/obstacle_stop.param.yaml
@@ -85,6 +85,8 @@
         outside_obstacle: # Parameters for predicting if an obstacle will cut in. Pointcloud obstacles are not supported.
           estimation_time_horizon: 1.0
           max_lateral_velocity: 5.0 # maximum lateral velocity to consider the obstacle as a stop obstacle [m/s]
+          min_longitudinal_velocity: -8.0 # minimum longitudinal velocity to consider the obstacle as a stop obstacle [m/s]
+          max_moving_direction_angle: 2.44 # [rad] = 140 [deg], maximum angle of moving direction to consider the obstacle as a stop obstacle
           deceleration: # planner perceives the object will stop with this rate to avoid unnecessary stops [m/ss]
             default: 0.0
             pedestrian: 1.0


### PR DESCRIPTION
## Description
obstacle_slow_down, obstacle_stopの更新です。

lpf_gain_lat_distがこれまで事実上機能していないパラメータでしたが、これを削除し、
lpf_gain_lateral_distance: 0.7という新規パラメータを定義しました。

他ははcoreやuniverse側の機能追加への追従です


core: https://github.com/tier4/autoware_core/pull/52
universe: https://github.com/tier4/autoware_universe/pull/2457

## How was this PR tested?
psimでエンゲージできるところまで

## Notes for reviewers

None.

## Effects on system behavior

None.
