### PR TITLE
feat(turn_signal_decider): add threshold based on distance to lane bo…

### DIFF
--- a/autoware_launch/config/planning/scenario_planning/lane_driving/behavior_planning/behavior_path_planner/behavior_path_planner.param.yaml
+++ b/autoware_launch/config/planning/scenario_planning/lane_driving/behavior_planning/behavior_path_planner/behavior_path_planner.param.yaml
@@ -18,6 +18,7 @@
     turn_signal_search_time: 3.0
     turn_signal_shift_length_threshold: 0.3
     turn_signal_remaining_shift_length_threshold: 0.1
+    turn_signal_remaining_distance_to_bound_threshold: 1.3 # Distance from ego vehicle's front edge to the far-side boundary of the target merging lane. The turn signal will be turned off when the value is less than the threshold.
     turn_signal_on_swerving: true
 
     enable_akima_spline_first: false


### PR DESCRIPTION
## Description

Cherry-pick 

-https://github.com/autowarefoundation/autoware_launch/pull/1676

⚠️ Required PR:

- https://github.com/tier4/autoware_universe/pull/2471 

### Related link

- https://github.com/autowarefoundation/autoware_universe/pull/11519
- [TIER IV internal issue link](https://tier4.atlassian.net/browse/T4DEV-33570)
- [TIER IV internal issue link](https://tier4.atlassian.net/browse/T4DEV-33759)

| Change type   | Parameter Name | Type     | Default Value | Description       |
|:--------------|:---------------|:---------|:--------------|:------------------|
| Added | `turn_signal_remaining_distance_to_bound_threshold`   | `double` | `1.4`         | Distance from ego vehicle's front edge to the far-side boundary of the target merging lane. The turn signal will be turned off when the value is less than the threshold. |

## How was this PR tested?

## Notes for reviewers

None.

## Effects on system behavior

None.
