### PR TITLE
feat: re-add `backport.yaml` into sync-files

### DIFF
--- a/.github/sync-files.yaml
+++ b/.github/sync-files.yaml
@@ -31,3 +31,6 @@
     - source: .github/workflows/build-and-test.yaml
     - source: .github/workflows/build-and-test-differential.yaml
     - source: .github/workflows/cancel-previous-workflows.yaml
+- repository: autowarefoundation/autoware
+  files:
+    - source: .github/workflows/backport.yaml


### PR DESCRIPTION
## Description

Revert #792 in the sense that `.github/workflows/backport.yaml` is added to the sync-files list again.
Since https://github.com/autowarefoundation/sync-file-templates does not have `backport.yaml` unlike https://github.com/autowarefoundation/autoware , the source repository `backport.yaml` is AWF autoware as an exception.

See #792 for the discussion.

## How was this PR tested?

The sync-file workflow runs: see https://github.com/tier4/autoware_launch/actions/runs/19419559966 .
(The actual file change will become available once https://github.com/autowarefoundation/autoware/pull/6583 has been merged.)

## Notes for reviewers

In the long run, I suggest to unify the workflow sync sources into a TIER IV's own sync file templates, instead of direct sync from AWF.

## Effects on system behavior

None.
