### PR TITLE
feat(autoware_behavior_velocity_traffic_light_module): support arrow-aware passing judgment on yellow signal

### DIFF
--- a/autoware_launch/config/planning/scenario_planning/lane_driving/behavior_planning/behavior_velocity_planner/traffic_light.param.yaml
+++ b/autoware_launch/config/planning/scenario_planning/lane_driving/behavior_planning/behavior_velocity_planner/traffic_light.param.yaml
@@ -7,6 +7,7 @@
       yellow_lamp_period: 2.75
       enable_pass_judge: true
       enable_rtc: false # If set to true, the scene modules require approval from the rtc (request to cooperate) function. If set to false, the modules can be executed without requiring rtc approval
+      enable_arrow_aware_yellow_passing: false
 
       v2i:
         use_rest_time: false


### PR DESCRIPTION
Ticket: [ticket](https://tier4.atlassian.net/browse/RT0-39185)
## Description
cherry pick: https://github.com/autowarefoundation/autoware_universe/pull/11704  
[check here](https://github.com/tier4/autoware_universe/pull/2574)
### Overview:
This PR improves the stop/pass judgment logic for yellow signals in turn lanes equipped with traffic light arrows. It prevents unnecessary stops when the signal transitions from "Green" to "Yellow," enabling smoother traffic flow.

### Problem:
Currently, when a traffic light transitions in the sequence of "Green -> Yellow -> Red + Arrow" while the vehicle is in a left/right turn lane, the system generates a stop line during the Yellow phase, causing the vehicle to stop. This behavior can obstruct traffic flow in situations where the vehicle should ideally proceed through the intersection on yellow to complete the turn (or wait for the arrow signal inside the intersection).

## How was this PR tested?
https://github.com/autowarefoundation/autoware_universe/pull/11704 
## Notes for reviewers

None.

## Effects on system behavior

None.
