### PR TITLE
feat(autoware_launch): use customized adapi config

### DIFF
--- a/autoware_launch/config/system/default_adapi/default_adapi.param.yaml
+++ b/autoware_launch/config/system/default_adapi/default_adapi.param.yaml
@@ -1,0 +1,45 @@
+/**:
+  ros__parameters:
+    diagnostic_updater:
+      period: 1.0
+      use_fqn: true
+
+/adapi/node/autoware_state:
+  ros__parameters:
+    update_rate: 10.0
+
+/adapi/node/motion:
+  ros__parameters:
+    require_accept_start: false
+    stop_check_duration: 1.0
+
+/adapi/node/routing:
+  ros__parameters:
+    stop_check_duration: 1.0
+
+/adapi/node/vehicle_metrics:
+  ros__parameters:
+    update_rate: 0.1
+    max_energy_level: 100.0
+
+/adapi/node/vehicle_door:
+  ros__parameters:
+    check_autoware_control: true
+
+/adapi/node/manual/local:
+  ros__parameters:
+    mode: local
+
+/adapi/node/manual/remote:
+  ros__parameters:
+    mode: remote
+
+/adapi/node/fail_safe:
+  ros__parameters:
+    mrm_descriptions:
+      emergency_stop:
+        behavior: 2
+        description: "Emergency stop"
+      comfortable_stop:
+        behavior: 3
+        description: "Comfortable stop"

--- a/autoware_launch/launch/components/tier4_autoware_api_component.launch.xml
+++ b/autoware_launch/launch/components/tier4_autoware_api_component.launch.xml
@@ -17,5 +17,8 @@
 
   <include file="$(find-pkg-share tier4_autoware_api_launch)/launch/autoware_api.launch.xml">
     <arg name="launch_deprecated_api" value="$(var launch_deprecated_api)"/>
+    <arg name="rosbridge_enabled" value="$(var rosbridge_enabled)"/>
+    <arg name="rosbridge_max_message_size" value="$(var rosbridge_max_message_size)"/>
+    <arg name="default_adapi_param_path" value="$(find-pkg-share autoware_launch)/config/system/default_adapi/default_adapi.param.yaml"/>
   </include>
 </launch>


### PR DESCRIPTION
## Description

Add param config for default_adapi package.
This is the same except for the `max_energy_level` at default settings.

## How was this PR tested?

Check autonomous driving in planning simulator.
Check API energy level is 1/100 of vehicle status topic.

```bash
ros2 topic pub /vehicle/status/battery_charge tier4_vehicle_msgs/msg/BatteryStatus "{stamp: now, energy_level: 50.0}"
```

```bash
ros2 topic echo /api/vehicle/metrics 
stamp:
  sec: 1765520724
  nanosec: 813399918
energy: 0.5
```




## Notes for reviewers

None.

## Effects on system behavior

None.
