### PR TITLE
fix(tier4 diagnostics): check route state

### DIFF
--- a/autoware_launch/config/system/tier4_diagnostics/planning.yaml
+++ b/autoware_launch/config/system/tier4_diagnostics/planning.yaml
@@ -23,6 +23,7 @@ units:
   - path: /planning/emergency_stop
     type: and
     list:
+      - { type: link, link: /planning/000-component_status/route_state }
       - { type: link, link: /planning/001-topic_status/route-error }
       - { type: link, link: /planning/001-topic_status/trajectory-error }
       - { type: link, link: /planning/003-trajectory_finite_validation-error }
@@ -52,6 +53,12 @@ units:
 
   - path: /planning/none
     type: and
+
+  - path: /planning/000-component_status/route_state
+    type: diag
+    node: /adapi/node/routing
+    name: state
+    timeout: 1.0
 
   - path: /planning/001-topic_status/route-error
     type: warn-to-ok


### PR DESCRIPTION
## Description

　`diagnostics` -> `tier4_diagnostics` の[移行](https://github.com/tier4/autoware_launch/pull/698)の際に失われた、RouteState の監視 diag を追加します。

　Add the RouteState monitoring diag path that was lost during the migration from `diagnostics` to `tier4_diagnostics`.

ref link: [TIER IV INTERNAL LINK](https://star4.slack.com/archives/C03QU7K50D8/p1766057734061669)

## How was this PR tested?

　PSim で経路を設定後、Clear Route で経路設定を解除し、Error Diag Graph 表示に追加した diag path が表示されることを確認。

## Notes for reviewers

　Planning/Control コンポーネントのパイプラインは transient_local なトピックを持つため、ルートが設定されていないことの監視は topic_state_monitor では不十分です。

　The pipeline of the Planning/Control component contains transient_local topics, so monitoring for the absence of LL2 route is insufficient with topic_state_monitor.

## Effects on system behavior

　Planning Component が LL2 ルート計画を保持していない際には、エンゲージが禁止されます。

　Engagement is prohibited when the Planning Component does not hold an LL2 route.
