### PR TITLE
fix(tier4 diagnostics): check duplicated node

### DIFF
--- a/autoware_launch/config/system/tier4_diagnostics/system.yaml
+++ b/autoware_launch/config/system/tier4_diagnostics/system.yaml
@@ -25,6 +25,7 @@ units:
     list:
       - { type: link, link: /system/001-topic_status-error }
       - { type: link, link: /system/002-emergency_stop_operation-error }
+      - { type: link, link: /system/003-duplicated_node_checker }
 
   - path: /system/comfortable_stop
     type: and
@@ -46,6 +47,11 @@ units:
     item:
       type: link
       link: /system/002-emergency_stop_operation
+
+  - path: /system/003-duplicated_node_checker
+    type: diag
+    node: duplicated_node_checker
+    name: duplicated_node_checker
 
   - path: /system/001-topic_status
     type: diag


### PR DESCRIPTION
## Description

　`diagnostics` -> `tier4_diagnostics` の[移行](https://github.com/tier4/autoware_launch/pull/699)の際に失われた、duplicated_node_checker の監視 diag を追加します。

　Add the duplicated_node_checker monitoring diag path that was lost during the migration from `diagnostics` to `tier4_diagnostics`.

ref link: [TIER IV INTERNAL LINK](https://star4.slack.com/archives/C03QU7K50D8/p1766057734061669)

## How was this PR tested?

　複数のPSimを同時に起動し、Error Diag Graph 表示に追加した diag path が表示されることを確認。 
## Notes for reviewers

　None.

## Effects on system behavior

　重複したノードが起動している際に、エンゲージを禁止します。
