### PR TITLE
feat(autoware_launch): move tier4 api adapter

### DIFF
--- a/autoware_launch/launch/components/tier4_autoware_api_component.launch.xml
+++ b/autoware_launch/launch/components/tier4_autoware_api_component.launch.xml
@@ -24,7 +24,7 @@
   <!-- AD API -->
   <group>
     <include file="$(find-pkg-share tier4_autoware_api_launch)/launch/autoware_api.launch.xml">
-      <!-- The evaluiation adapter is temporarily disabled because the interface name overlaps with TIER IV API.-->
+      <!-- The evaluation adapter is temporarily disabled because the interface name overlaps with TIER IV API.-->
       <!-- <arg name="launch_evaluation_adapter" value="$(var scenario_simulation)"/> -->
       <arg name="launch_evaluation_adapter" value="false"/>
       <arg name="default_adapi_param_path" value="$(find-pkg-share autoware_launch)/config/system/default_adapi/default_adapi.param.yaml"/>

--- a/autoware_launch/launch/components/tier4_autoware_api_component.launch.xml
+++ b/autoware_launch/launch/components/tier4_autoware_api_component.launch.xml
@@ -1,15 +1,17 @@
 <?xml version="1.0"?>
 <launch>
-  <!-- For API EOL information, see https://github.com/tier4/tier4_ad_api_adaptor -->
-  <!-- Pilot.Auto will continue to use 1 to align with Web.Auto release. -->
-  <arg name="api_mode" default="1" description="options: 0(All), 1(Without 2025/09 EOL API), 2(Without 2025/12 EOL API)"/>
-
   <!-- Fork the repository and add the parameters here if needed. -->
+  <arg name="scenario_simulation" default="false"/>
+  <arg name="use_sim_time" default="false"/>
+  <arg name="vehicle_model" default="sample_vehicle"/>
+
   <arg name="launch_tier4_api" default="true"/>
   <arg name="rosbridge_enabled" default="true"/>
   <arg name="rosbridge_max_message_size" default="1000000000"/>
-  <arg name="use_sim_time" default="false"/>
-  <arg name="vehicle_model" default="sample_vehicle"/>
+
+  <!-- For API EOL information, see https://github.com/tier4/tier4_ad_api_adaptor -->
+  <!-- Pilot.Auto will continue to use 1 to align with Web.Auto release. -->
+  <arg name="api_mode" default="1" description="options: 0(All), 1(Without 2025/09 EOL API), 2(Without 2025/12 EOL API)"/>
 
   <!-- Global parameters -->
   <group scoped="false">
@@ -22,6 +24,9 @@
   <!-- AD API -->
   <group>
     <include file="$(find-pkg-share tier4_autoware_api_launch)/launch/autoware_api.launch.xml">
+      <!-- The evaluiation adapter is temporarily disabled because the interface name overlaps with TIER IV API.-->
+      <!-- <arg name="launch_evaluation_adapter" value="$(var scenario_simulation)"/> -->
+      <arg name="launch_evaluation_adapter" value="false"/>
       <arg name="default_adapi_param_path" value="$(find-pkg-share autoware_launch)/config/system/default_adapi/default_adapi.param.yaml"/>
     </include>
   </group>

--- a/autoware_launch/launch/components/tier4_autoware_api_component.launch.xml
+++ b/autoware_launch/launch/components/tier4_autoware_api_component.launch.xml
@@ -1,7 +1,11 @@
 <?xml version="1.0"?>
 <launch>
+  <!-- For API EOL information, see https://github.com/tier4/tier4_ad_api_adaptor -->
+  <!-- Pilot.Auto will continue to use 1 to align with Web.Auto release. -->
+  <arg name="api_mode" default="1" description="options: 0(All), 1(Without 2025/09 EOL API), 2(Without 2025/12 EOL API)"/>
+
   <!-- Fork the repository and add the parameters here if needed. -->
-  <arg name="launch_deprecated_api" default="true"/>
+  <arg name="launch_tier4_api" default="true"/>
   <arg name="rosbridge_enabled" default="true"/>
   <arg name="rosbridge_max_message_size" default="1000000000"/>
   <arg name="use_sim_time" default="false"/>
@@ -15,10 +19,19 @@
     </include>
   </group>
 
-  <include file="$(find-pkg-share tier4_autoware_api_launch)/launch/autoware_api.launch.xml">
-    <arg name="launch_deprecated_api" value="$(var launch_deprecated_api)"/>
-    <arg name="rosbridge_enabled" value="$(var rosbridge_enabled)"/>
-    <arg name="rosbridge_max_message_size" value="$(var rosbridge_max_message_size)"/>
-    <arg name="default_adapi_param_path" value="$(find-pkg-share autoware_launch)/config/system/default_adapi/default_adapi.param.yaml"/>
-  </include>
+  <!-- AD API -->
+  <group>
+    <include file="$(find-pkg-share tier4_autoware_api_launch)/launch/autoware_api.launch.xml">
+      <arg name="default_adapi_param_path" value="$(find-pkg-share autoware_launch)/config/system/default_adapi/default_adapi.param.yaml"/>
+    </include>
+  </group>
+
+  <!-- TIER IV -->
+  <group if="$(var launch_tier4_api)">
+    <include file="$(find-pkg-share tier4_autoware_api_extension_launch)/launch/tier4_autoware_api_extension.launch.xml">
+      <arg name="api_mode" value="$(var api_mode)"/>
+      <arg name="rosbridge_enabled" value="$(var rosbridge_enabled)"/>
+      <arg name="rosbridge_max_message_size" value="$(var rosbridge_max_message_size)"/>
+    </include>
+  </group>
 </launch>


### PR DESCRIPTION
## Description

Parent issue: https://github.com/autowarefoundation/autoware/issues/3096

With the removal of TIER IV API from AWF, [the launch_evaluation_adapter option has been added](https://github.com/autowarefoundation/autoware_universe/pull/11831). Ideally, this should be set to true when running a scenario simulation, [like the AWF repository](https://github.com/autowarefoundation/autoware_launch/pull/1745), but for compatibility reasons, the evaluation adapter provides the same interface as the TIER IV API.

So at the moment, TIER IV API and the evaluation adapter  cannot be running at the same time, so the evaluation adapter will always be disabled in Pilot.Auto.

## How was this PR tested?

https://evaluation.tier4.jp/evaluation/reports/38012857-3237-53cc-b4f6-57bd9283a894?project_id=autoware_dev

## Notes for reviewers

None.

## Effects on system behavior

None.
