### PR TITLE
feat(foolproof): add foolproof diagnostics configuration and links

### DIFF
--- a/autoware_launch/config/system/tier4_diagnostics/autoware-main.yaml
+++ b/autoware_launch/config/system/tier4_diagnostics/autoware-main.yaml
@@ -9,6 +9,7 @@ files:
   # - { path: $(dirname)/sensing.yaml }
   - { path: $(dirname)/system.yaml }
   - { path: $(dirname)/vehicle.yaml }
+  - { path: $(dirname)/foolproof.yaml }
 
 units:
   - path: /autoware/modes/local
@@ -30,6 +31,7 @@ units:
       - { type: link, link: /control/autonomous_available }
       - { type: link, link: /vehicle/autonomous_available }
       - { type: link, link: /system/autonomous_available }
+      - { type: link, link: /foolproof/autonomous_available }
 
   - path: /autoware/modes/pull_over
     type: and
@@ -41,6 +43,7 @@ units:
       - { type: link, link: /control/pull_over_available }
       - { type: link, link: /vehicle/pull_over_available }
       - { type: link, link: /system/pull_over_available }
+      - { type: link, link: /foolproof/pull_over_available }
 
   - path: /autoware/modes/comfortable_stop
     type: and
@@ -52,6 +55,7 @@ units:
       - { type: link, link: /control/comfortable_stop_available }
       - { type: link, link: /vehicle/comfortable_stop_available }
       - { type: link, link: /system/comfortable_stop_available }
+      - { type: link, link: /foolproof/comfortable_stop_available }
 
   - path: /autoware/modes/emergency_stop
     type: ok

--- a/autoware_launch/config/system/tier4_diagnostics/dummy_diag_publisher.param.yaml
+++ b/autoware_launch/config/system/tier4_diagnostics/dummy_diag_publisher.param.yaml
@@ -46,3 +46,11 @@
 
       ## /perception/002-detection_delay
       "multi_object_tracker: Perception delay check from original header stamp": default
+
+      ## letterbox_monitor
+      "autoware_diagnostics_bridge_node_main: main_autoware_node_alive": default
+
+      ## update_status_checker
+      "autoware_diagnostics_bridge_node_main: main_update_status_checker_ota": default
+      "autoware_diagnostics_bridge_node_main: main_update_status_checker_map": default
+      "autoware_diagnostics_bridge_node_main: main_update_status_checker_unrecoverable": default

--- a/autoware_launch/config/system/tier4_diagnostics/foolproof.yaml
+++ b/autoware_launch/config/system/tier4_diagnostics/foolproof.yaml
@@ -69,7 +69,6 @@ units:
     timeout: 3.0
     latch: 0.0
 
-
   # Heartbeat, watch other ECU is alive or not
   # - path: /foolproof/logging/heartbeat
   #   type: diag

--- a/autoware_launch/config/system/tier4_diagnostics/foolproof.yaml
+++ b/autoware_launch/config/system/tier4_diagnostics/foolproof.yaml
@@ -1,0 +1,79 @@
+units:
+  - path: /foolproof/autonomous_available
+    type: and
+    list:
+      - { type: link, link: /foolproof/emergency_stop }
+      - { type: link, link: /foolproof/pull_over }
+      - { type: link, link: /foolproof/comfortable_stop }
+
+  - path: /foolproof/pull_over_available
+    type: and
+    list:
+      - { type: link, link: /foolproof/emergency_stop }
+      - { type: link, link: /foolproof/comfortable_stop }
+
+  - path: /foolproof/comfortable_stop_available
+    type: and
+    list:
+      - { type: link, link: /foolproof/emergency_stop }
+
+  # *******************************************************************************
+  # NOTE: Please modify this section according to your environment and requirements.
+  # *******************************************************************************
+  - path: /foolproof/emergency_stop
+    type: and
+    list:
+      - { type: link, link: /foolproof/main/autoware_node_alive }
+
+  - path: /foolproof/pull_over
+    type: and
+
+  - path: /foolproof/comfortable_stop
+    type: and
+    list:
+      - { type: link, link: /foolproof/main/update_status_ota }
+      - { type: link, link: /foolproof/main/update_status_map }
+      - { type: link, link: /foolproof/main/update_status_unrecoverable }
+
+  # *******************************************************************************
+  # Set path, node to identify and name for each individual error.
+  # *******************************************************************************
+
+  # letterbox_monitor
+  - path: /foolproof/main/autoware_node_alive
+    type: diag
+    node: autoware_diagnostics_bridge_node_main # autoware_diagnostics_bridge_node_<host>
+    name: main_autoware_node_alive # <host>_<mrm_name_suffix>
+    timeout: 3.0
+    latch: 0.0
+
+  # update_status_checker
+  - path: /foolproof/main/update_status_ota
+    type: diag
+    node: autoware_diagnostics_bridge_node_main # autoware_diagnostics_bridge_node_<host>
+    name: main_update_status_checker_ota # <host>_<mrm_name_suffix>
+    timeout: 3.0
+    latch: 0.0
+
+  - path: /foolproof/main/update_status_map
+    type: diag
+    node: autoware_diagnostics_bridge_node_main # autoware_diagnostics_bridge_node_<host>
+    name: main_update_status_checker_map # <host>_<mrm_name_suffix>
+    timeout: 3.0
+    latch: 0.0
+
+  - path: /foolproof/main/update_status_unrecoverable
+    type: diag
+    node: autoware_diagnostics_bridge_node_main # autoware_diagnostics_bridge_node_<host>
+    name: main_update_status_checker_unrecoverable # <host>_<mrm_name_suffix>
+    timeout: 3.0
+    latch: 0.0
+
+
+  # Heartbeat, watch other ECU is alive or not
+  # - path: /foolproof/logging/heartbeat
+  #   type: diag
+  #   node: autoware_diagnostics_bridge_node_logging
+  #   name: heartbeat
+  #   timeout: 3.0
+  #   latch: 0.0


### PR DESCRIPTION
## Description

Since the hostnames of the ECUs running Autoware have been unified across reference design,
 I am adding foolproof roles that were previously dependent on specific hostnames.

The following check functions are added:

* node_alive monitoring (letterbox_monitor)
* update detection (update_status_checker)


## How was this PR tested?




## Notes for reviewers

None.

## Effects on system behavior

None.
