### PR TITLE
ci: batch sync upstream improvements

### DIFF
--- a/.github/upstreams.yaml
+++ b/.github/upstreams.yaml
@@ -7,6 +7,8 @@ tier4/autoware_launch:
       syncs:
         - upstream: main
           base: tier4/main
+          reviewers: # use actual GitHub users or teams
+            - rej55
 
 ### Example for downstream ###
 
@@ -19,5 +21,11 @@ tier4/autoware_launch.oo:
       syncs:
         - upstream: stable
           base: tier4/main
+          reviewers: # use actual GitHub users or teams
+            - person-in-charge-supervisor
+            - person-in-charge-2
         # - upstream: beta/v0.xx
         #   base: beta/v0.yy
+        #   reviewers:
+        #     - person-in-charge-supervisor
+        #     - person-in-charge-for-this-release

--- a/.github/workflows/sync-upstream-batch.yaml
+++ b/.github/workflows/sync-upstream-batch.yaml
@@ -51,7 +51,6 @@ jobs:
                 | .value.syncs[]
                 | {
                     \"upstream_id\": \$upstream_id,
-                    \"upstream_branch\": .upstream,
                     \"base_branch\": .base
                   }
               ]
@@ -75,5 +74,4 @@ jobs:
     with:
       base-branch: ${{ matrix.sync.base_branch }}
       upstream-id: ${{ matrix.sync.upstream_id }}
-      upstream-branch: ${{ matrix.sync.upstream_branch }}
     secrets: inherit

--- a/.github/workflows/sync-upstream.yaml
+++ b/.github/workflows/sync-upstream.yaml
@@ -11,10 +11,6 @@ on:
         description: Upstream ID from config (defaults to default-upstream-id in .github/upstreams.yaml if not provided)
         required: false
         type: string
-      upstream-branch:
-        description: Upstream branch to sync from (auto-detected from .github/upstreams.yaml if not provided)
-        required: false
-        type: string
   workflow_call:
     inputs:
       base-branch:
@@ -23,10 +19,6 @@ on:
         type: string
       upstream-id:
         description: Upstream ID from config (defaults to default-upstream-id in .github/upstreams.yaml if not provided)
-        required: false
-        type: string
-      upstream-branch:
-        description: Upstream branch to sync from (auto-detected from .github/upstreams.yaml if not provided)
         required: false
         type: string
     secrets:
@@ -120,21 +112,25 @@ jobs:
           fi
           echo "base-branch=$BASE_BRANCH" >> "$GITHUB_OUTPUT"
 
-          # Determine upstream branch to use
-          if [ -z "${{ inputs.upstream-branch }}" ]; then
-            UPSTREAM_BRANCH=$(yq eval ".\"$BASE_REPO\".upstreams.\"$UPSTREAM_ID\".syncs[] | select(.base == \"$BASE_BRANCH\") | .upstream" "$CONFIG_FILE" | head -n 1)
-            if [ "$UPSTREAM_BRANCH" = "null" ] || [ -z "$UPSTREAM_BRANCH" ]; then
-              echo "Error: upstream-branch was not provided and no syncs entry matches base-branch ($BASE_BRANCH) for upstream ($UPSTREAM_ID)"
-              exit 1
-            fi
-          else
-            UPSTREAM_BRANCH="${{ inputs.upstream-branch }}"
-            if ! [[ "$UPSTREAM_BRANCH" =~ ^[A-Za-z0-9._/-]+$ ]]; then
-              echo "Error: upstream-branch ($UPSTREAM_BRANCH) contains invalid characters"
-              exit 1
-            fi
+          # Determine upstream branch and reviewers from matching sync entry
+          MATCHING_SYNCS=$(yq eval -o=json "
+            .\"$BASE_REPO\".upstreams.\"$UPSTREAM_ID\".syncs // []
+            | map(select(.base == \"$BASE_BRANCH\"))
+          " "$CONFIG_FILE")
+          MATCH_COUNT=$(echo "$MATCHING_SYNCS" | jq 'length')
+          if [ "$MATCH_COUNT" -eq 0 ]; then
+            echo "Error: no syncs entry matches base-branch ($BASE_BRANCH) for upstream ($UPSTREAM_ID)"
+            exit 1
           fi
+          if [ "$MATCH_COUNT" -gt 1 ]; then
+            echo "Error: multiple syncs entries match base-branch ($BASE_BRANCH) for upstream ($UPSTREAM_ID)"
+            exit 1
+          fi
+          UPSTREAM_BRANCH=$(echo "$MATCHING_SYNCS" | jq -r '.[0].upstream')
           echo "upstream-branch=$UPSTREAM_BRANCH" >> "$GITHUB_OUTPUT"
+
+          REVIEWERS=$(echo "$MATCHING_SYNCS" | jq -r '.[0].reviewers // [] | join(",")')
+          echo "reviewers=$REVIEWERS" >> "$GITHUB_OUTPUT"
 
           # Create sanitized branch name by replacing slashes with underscores
           BASE_BRANCH_CLEAN="${BASE_BRANCH//\//_}"
@@ -152,6 +148,7 @@ jobs:
           sync-target-repository: ${{ steps.parse-config.outputs.upstream-url }}
           sync-target-branch: ${{ steps.parse-config.outputs.upstream-branch }}
           pr-title: "chore: sync ${{ steps.parse-config.outputs.base-branch }} from ${{ steps.parse-config.outputs.upstream-id }}:${{ steps.parse-config.outputs.upstream-branch }}"
+          pr-reviewers: ${{ steps.parse-config.outputs.reviewers }}
           pr-labels: |
             bot
             sync-upstream


### PR DESCRIPTION
## Description

Follow-up from #1284 .

* Remove manual specification support for upstream branch. Only the base branch and upstream branch pairs explicitly specified in .github/upstreams.yaml are supported.
* Add support for PR reviewers.

## How was this PR tested?

* PR reviewers extraction logic:

```bash
$ yq eval -o=json "
            .\"tier4/autoware_launch.oo\".upstreams.\"vanilla\".syncs // []
            | map(select(.base == \"tier4/main\"))
          " .github/upstreams.yaml | jq -r '.[0].reviewers // [] | join(",")'
person-in-charge-supervisor,person-in-charge-2
```

* Integration test

https://github.com/paulsohn/autoware_launch/actions/runs/21928852254 (status is failed but the PR is generated and reviewer is assigned)
https://github.com/paulsohn/autoware_launch/pull/5

## Notes for reviewers

None.

## Effects on system behavior

None.
