### PR TITLE
chore: migrate to nebula 0.3.x

### DIFF
--- a/aip_launcher/aip_common_sensor_launch/launch/nebula_node_container.launch.py
+++ b/aip_launcher/aip_common_sensor_launch/launch/nebula_node_container.launch.py
@@ -87,14 +87,15 @@ def make_nebula_nodes(context):
     # Model and make
     sensor_model = LaunchConfiguration("sensor_model").perform(context)
     sensor_make, sensor_extension = get_lidar_make(sensor_model)
-    nebula_decoders_share_dir = get_package_share_directory("nebula_decoders")
+    nebula_decoders_share_dir = get_package_share_directory(
+        "nebula_" + sensor_make.lower() + "_decoders"
+    )
 
     # Calibration file
     if sensor_extension is not None:  # Velodyne and Hesai
         sensor_calib_fp = os.path.join(
             nebula_decoders_share_dir,
             "calibration",
-            sensor_make.lower(),
             sensor_model + sensor_extension,
         )
         assert os.path.exists(
@@ -105,7 +106,7 @@ def make_nebula_nodes(context):
 
     return [
         ComposableNode(
-            package="nebula_ros",
+            package="nebula_" + sensor_make.lower(),
             plugin=sensor_make + "RosWrapper",
             name=sensor_make.lower() + "_ros_wrapper_node",
             parameters=[

--- a/aip_launcher/aip_common_sensor_launch/package.xml
+++ b/aip_launcher/aip_common_sensor_launch/package.xml
@@ -17,8 +17,7 @@
   <exec_depend>autoware_radar_tracks_noise_filter</exec_depend>
   <exec_depend>autoware_velodyne_monitor</exec_depend>
   <exec_depend>individual_params</exec_depend>
-  <exec_depend>nebula_decoders</exec_depend>
-  <exec_depend>nebula_sensor_driver</exec_depend>
+  <exec_depend>nebula</exec_depend>
   <exec_depend>pe_ars408_ros</exec_depend>
   <exec_depend>ros2_socketcan</exec_depend>
 


### PR DESCRIPTION
## Description

Update nebula launcher code in aip, following the convention of https://github.com/autowarefoundation/autoware_launch/pull/1749 . 

## How was this PR tested?

None, while it follows the convention of sample_sensor_kit_launch.

## Notes for reviewers

Since each individual aip is now moved into each reference design, downstream aip should be updated as well. https://github.com/tier4/aip_launcher/pull/658

## Effects on system behavior

The system now requires nebula 0.3.x. https://github.com/tier4/nebula?tab=readme-ov-file#migration-to-nebula-030
