### PR TITLE
chore: restore omitted negative crop box from tier4/aip_launcher#650

### DIFF
--- a/aip_launcher/aip_common_sensor_launch/launch/nebula_node_container.launch.py
+++ b/aip_launcher/aip_common_sensor_launch/launch/nebula_node_container.launch.py
@@ -199,6 +199,7 @@ def make_cuda_preprocessor_nodes(context):
         vehicle_info["max_height_offset"],
         mirror_info["max_height_offset"],
     ]
+    preprocessor_parameters["crop_box.negative"] = [True, True]
 
     return [
         ComposableNode(


### PR DESCRIPTION
## Description

During migration, negative crop box config in https://github.com/tier4/aip_launcher/pull/650 was omitted accidentally.

## How was this PR tested?
