### PR TITLE
chore: add build-and-test-differential label

### DIFF
--- a/.github/workflows/sync-upstream.yaml
+++ b/.github/workflows/sync-upstream.yaml
@@ -171,4 +171,5 @@ jobs:
           pr-labels: |
             bot
             sync-upstream
+            run:build-and-test-differential
           auto-merge-method: merge


### PR DESCRIPTION
## Description

To run build-and-test-differential automatically, add label in sync-upstream.

## How was this PR tested?

https://github.com/tier4/autoware_launch/actions/runs/22184587874

https://github.com/tier4/autoware_launch/pull/1299

## Notes for reviewers

None.

## Effects on system behavior

None.
