### PR TITLE
fix(tier4_diagnostics): remove initial pose topic from diag

### DIFF
--- a/autoware_launch/config/system/tier4_diagnostics/localization.yaml
+++ b/autoware_launch/config/system/tier4_diagnostics/localization.yaml
@@ -23,7 +23,6 @@ units:
   - path: /localization/emergency_stop
     type: and
     list:
-      - { type: link, link: /localization/001-topic_status/initialpose-error }
       - { type: link, link: /localization/001-topic_status/pose_twist_fusion_filter-error }
       - { type: link, link: /localization/002-tf-error }
       - { type: link, link: /localization/003-matching_score-error }
@@ -37,12 +36,6 @@ units:
 
   - path: /localization/none
     type: and
-
-  - path: /localization/001-topic_status/initialpose-error
-    type: warn-to-ok
-    item:
-      type: link
-      link: /localization/001-topic_status/initialpose
 
   - path: /localization/001-topic_status/pose_twist_fusion_filter-error
     type: warn-to-ok
@@ -67,12 +60,6 @@ units:
     item:
       type: link
       link: /localization/004-accuracy
-
-  - path: /localization/001-topic_status/initialpose
-    type: diag
-    node: topic_state_monitor_initialpose3d
-    name: localization_topic_status
-    timeout: 1.0
 
   - path: /localization/001-topic_status/pose_twist_fusion_filter
     type: diag


### PR DESCRIPTION
## Description

By https://github.com/autowarefoundation/autoware_launch/pull/1756, `/initialpose3d` topic was removed.
However, in tier4_diagnostics config, it remains diag settings for topic status of `/initialpose3d`.
In this PR, I removed the setting.

## How was this PR tested?

https://star4.slack.com/archives/C07K1PPNPTR/p1771564784758079?thread_ts=1771564260.227509&cid=C07K1PPNPTR

## Notes for reviewers

None.

## Effects on system behavior

None.
