### PR TITLE
fix(autoware_system_monitor): add threshold parameters for mem_monitor

### DIFF
--- a/autoware_launch/config/system/system_monitor/mem_monitor.param.yaml
+++ b/autoware_launch/config/system/system_monitor/mem_monitor.param.yaml
@@ -1,3 +1,5 @@
 /**:
   ros__parameters:
-    available_size: 1024 # MB
+    available_size: 4096 # MiB
+    warning_margin: 2048 # MiB
+    swap_error_threshold: 1024 # MiB


### PR DESCRIPTION
## Description
I'm writing this PR to change and add threshold for Pilot-auto's `threshold`.
https://github.com/autowarefoundation/autoware_universe/pull/11971

Based on [the TIER IV internal document](https://tier4.atlassian.net/wiki/spaces/XFST/pages/4697620546/X1+2025+12+11+12), we have updated the diagnostic logic and threshold criteria. 

The error threshold defined here would be 4GiB. The error threshold would 6GiB, but it would be treated as non-error. Swap will not be used, but it would be the default value defined in OSS-version Autoware.

```bash
    available_size: 4096 # MiB
    warning_margin: 2048 # MiB
    swap_error_threshold: 1024 # MiB
```

## How was this PR tested?

```bash
ros2 launch autoware_launch planning_simulator.launch.xml map_path:=$HOME/autoware_map/sample-map-planning/ vehicle_model:=sample_vehicle sensor_model:=awsim_sensor_kit launch_system_monitor:=true
```

Launch runtime monitor.
```bash
ros2 run rqt_runtime_monitor rqt_runtime_monitor 
```

<img width="1299" height="887" alt="image" src="https://github.com/user-attachments/assets/cd7ccfdc-1663-4e9f-91b7-1230b9a5611f" />


Add memory load as additional stimulus.
```bash
python3 -c 'import time; a = "a" * (50*1024**3); time.sleep(10)'
```
The above example shows 50 GiB data occupies memory space. The magic number of 50 is the magic number for my environment. It would be configured for each envirionement.

When the available size was lower than 4GiB, the diagnostic result became error.
<img width="1299" height="887" alt="image" src="https://github.com/user-attachments/assets/93ed17cc-3549-404e-85fe-f667ed0fdeb9" />


## Notes for reviewers

None.


## Effects on system behavior

For Pilot.Auto X2, the error definition will be updated along with the PR.
https://github.com/tier4/autoware_launch.x2/blob/e35bb07bea90421497e97cf273631f49f9f20d1b/autoware_launch/config/system/tier4_diagnostics/hardware.yaml#L56

<img width="1283" height="1438" alt="image" src="https://github.com/user-attachments/assets/55269183-9d05-41d3-bec1-ab6518e7179a" />
