### PR TITLE
fix(imu_scale_bias_estimator): ekf initializes only when it has in bounds samples

### DIFF
--- a/aip_launcher/aip_xx1_launch/config/gyro_scale_estimator.param.yaml
+++ b/aip_launcher/aip_xx1_launch/config/gyro_scale_estimator.param.yaml
@@ -29,6 +29,8 @@
       measurement_noise_r_angle: 0.00005
       min_covariance_angle: 1e-11
       decay_coefficient: 0.99999998
+      samples_in_bounds_to_init: 250
+      max_reinitialization_retries: 5
 
     scale_imu_injection:
       modify_imu_scale: false


### PR DESCRIPTION
## Description
Add imu_scale_bias_estimator parameters for https://github.com/autowarefoundation/autoware_universe/pull/11816

Related conversation: https://star4.slack.com/archives/C03QU7K50D8/p1772089587676019

## How was this PR tested?

## Notes for reviewers

None.

## Effects on system behavior

None.
