### PR TITLE
refactor(tier4_diagnostics): replace topic-state-error by behavior_path_planner

### DIFF
--- a/autoware_launch/config/system/tier4_diagnostics/autoware-carla.yaml
+++ b/autoware_launch/config/system/tier4_diagnostics/autoware-carla.yaml
@@ -129,14 +129,8 @@ units:
     list:
       - type: and
         list:
-          - { type: link, link: /autoware/planning/topic_rate_check/route }
           - { type: link, link: /autoware/planning/topic_rate_check/trajectory }
           - { type: link, link: /autoware/planning/trajectory_validation }
-
-  - path: /autoware/planning/topic_rate_check/route
-    type: diag
-    node: topic_state_monitor_mission_planning_route
-    name: planning_topic_status
 
   - path: /autoware/planning/topic_rate_check/trajectory
     type: diag

--- a/autoware_launch/config/system/tier4_diagnostics/dummy_diag_publisher.param.yaml
+++ b/autoware_launch/config/system/tier4_diagnostics/dummy_diag_publisher.param.yaml
@@ -15,9 +15,6 @@
   ros__parameters:
     required_diags:
       # localization
-      ## /localization/001-topic_status/pose_twist_fusion_filter
-      "topic_state_monitor_pose_twist_fusion_filter_pose: localization_topic_status": default
-
       ## /localization/002-tf
       "topic_state_monitor_transform_map_to_base_link: localization_topic_status": default
 
@@ -30,16 +27,6 @@
       # map
       ## /map/001-topic_status/pointcloud_map
       "topic_state_monitor_pointcloud_map: map_topic_status": default
-
-      # perception
-      ## /perception/001-topic_status/traffic_signals
-      "topic_state_monitor_traffic_light_recognition_traffic_signals: perception_topic_status": default
-
-      ## /perception/001-topic_status/objects
-      "topic_state_monitor_object_recognition_objects: perception_topic_status": default
-
-      ## /perception/001-topic_status/pointcloud
-      "topic_state_monitor_obstacle_segmentation_pointcloud: perception_topic_status": default
 
       ## /perception/002-detection_delay
       "multi_object_tracker: Tracker Timing Diagnostics": default

--- a/autoware_launch/config/system/tier4_diagnostics/localization.yaml
+++ b/autoware_launch/config/system/tier4_diagnostics/localization.yaml
@@ -23,7 +23,6 @@ units:
   - path: /localization/emergency_stop
     type: and
     list:
-      - { type: link, link: /localization/001-topic_status/pose_twist_fusion_filter-error }
       - { type: link, link: /localization/002-tf-error }
       - { type: link, link: /localization/003-matching_score-error }
       - { type: link, link: /localization/004-accuracy-error }
@@ -36,12 +35,6 @@ units:
 
   - path: /localization/none
     type: and
-
-  - path: /localization/001-topic_status/pose_twist_fusion_filter-error
-    type: warn-to-ok
-    item:
-      type: link
-      link: /localization/001-topic_status/pose_twist_fusion_filter
 
   - path: /localization/002-tf-error
     type: warn-to-ok
@@ -60,12 +53,6 @@ units:
     item:
       type: link
       link: /localization/004-accuracy
-
-  - path: /localization/001-topic_status/pose_twist_fusion_filter
-    type: diag
-    node: topic_state_monitor_pose_twist_fusion_filter_pose
-    name: localization_topic_status
-    timeout: 1.0
 
   - path: /localization/002-tf
     type: diag

--- a/autoware_launch/config/system/tier4_diagnostics/map.yaml
+++ b/autoware_launch/config/system/tier4_diagnostics/map.yaml
@@ -23,7 +23,6 @@ units:
   - path: /map/emergency_stop
     type: and
     list:
-      - { type: link, link: /map/001-topic_status/vector_map-error }
       - { type: link, link: /map/001-topic_status/pointcloud_map-error }
 
   - path: /map/comfortable_stop
@@ -35,23 +34,11 @@ units:
   - path: /map/none
     type: and
 
-  - path: /map/001-topic_status/vector_map-error
-    type: warn-to-ok
-    item:
-      type: link
-      link: /map/001-topic_status/vector_map
-
   - path: /map/001-topic_status/pointcloud_map-error
     type: warn-to-ok
     item:
       type: link
       link: /map/001-topic_status/pointcloud_map
-
-  - path: /map/001-topic_status/vector_map
-    type: diag
-    node: topic_state_monitor_vector_map
-    name: map_topic_status
-    timeout: 1.0
 
   - path: /map/001-topic_status/pointcloud_map
     type: diag

--- a/autoware_launch/config/system/tier4_diagnostics/perception.yaml
+++ b/autoware_launch/config/system/tier4_diagnostics/perception.yaml
@@ -23,9 +23,6 @@ units:
   - path: /perception/emergency_stop
     type: and
     list:
-      - { type: link, link: /perception/001-topic_status/traffic_signals-error }
-      - { type: link, link: /perception/001-topic_status/objects-error }
-      - { type: link, link: /perception/001-topic_status/pointcloud-error }
       - { type: link, link: /perception/002-detection_delay-error }
 
   - path: /perception/comfortable_stop
@@ -37,47 +34,11 @@ units:
   - path: /perception/none
     type: and
 
-  - path: /perception/001-topic_status/traffic_signals-error
-    type: warn-to-ok
-    item:
-      type: link
-      link: /perception/001-topic_status/traffic_signals
-
-  - path: /perception/001-topic_status/objects-error
-    type: warn-to-ok
-    item:
-      type: link
-      link: /perception/001-topic_status/objects
-
-  - path: /perception/001-topic_status/pointcloud-error
-    type: warn-to-ok
-    item:
-      type: link
-      link: /perception/001-topic_status/pointcloud
-
   - path: /perception/002-detection_delay-error
     type: warn-to-ok
     item:
       type: link
       link: /perception/002-detection_delay
-
-  - path: /perception/001-topic_status/traffic_signals
-    type: diag
-    node: topic_state_monitor_traffic_light_recognition_traffic_signals
-    name: perception_topic_status
-    timeout: 1.0
-
-  - path: /perception/001-topic_status/objects
-    type: diag
-    node: topic_state_monitor_object_recognition_objects
-    name: perception_topic_status
-    timeout: 1.0
-
-  - path: /perception/001-topic_status/pointcloud
-    type: diag
-    node: topic_state_monitor_obstacle_segmentation_pointcloud
-    name: perception_topic_status
-    timeout: 1.0
 
   - path: /perception/002-detection_delay
     type: diag

--- a/autoware_launch/config/system/tier4_diagnostics/planning.yaml
+++ b/autoware_launch/config/system/tier4_diagnostics/planning.yaml
@@ -24,7 +24,6 @@ units:
     type: and
     list:
       - { type: link, link: /planning/000-component_status/route_state }
-      - { type: link, link: /planning/001-topic_status/route-error }
       - { type: link, link: /planning/001-topic_status/trajectory-error }
       - { type: link, link: /planning/003-trajectory_finite_validation-error }
       - { type: link, link: /planning/004-trajectory_interval_validation-error }
@@ -44,6 +43,7 @@ units:
       - { type: link, link: /planning/018-trajectory_yaw_deviation_validation-error }
       - { type: link, link: /planning/019-trajectory_distance_deviation_validation-error }
       - { type: link, link: /planning/020-boundary_departure-error }
+      - { type: link, link: /planning/021-incoming-message-timeout-error }
 
   - path: /planning/comfortable_stop
     type: and
@@ -59,12 +59,6 @@ units:
     node: /adapi/node/routing
     name: state
     timeout: 1.0
-
-  - path: /planning/001-topic_status/route-error
-    type: warn-to-ok
-    item:
-      type: link
-      link: /planning/001-topic_status/route
 
   - path: /planning/001-topic_status/trajectory-error
     type: warn-to-ok
@@ -180,11 +174,11 @@ units:
       type: link
       link: /planning/020-boundary_departure
 
-  - path: /planning/001-topic_status/route
-    type: diag
-    node: topic_state_monitor_mission_planning_route
-    name: planning_topic_status
-    timeout: 1.0
+  - path: /planning/021-incoming-message-timeout-error
+    type: warn-to-ok
+    item:
+      type: link
+      link: /planning/021-incoming-message-timeout
 
   - path: /planning/001-topic_status/trajectory
     type: diag
@@ -298,3 +292,9 @@ units:
     type: diag
     node: motion_velocity_planner
     name: boundary_departure
+
+  - path: /planning/021-incoming-message-timeout
+    type: diag
+    node: behavior_path_planner
+    name: incoming_message_timeout
+    timeout: 1.0


### PR DESCRIPTION
## Description

Remove `topic_state_monitor`-based diagnostic entries that are now redundant, because `behavior_path_planner` internally monitors its input message timeouts (see autowarefoundation/autoware_universe#12075).

The following `topic_state_monitor` entries are removed from `tier4_diagnostics` config:

| Domain | Removed topic_state_monitor | Reason |
|---|---|---|
| localization | `pose_twist_fusion_filter` | Monitored as odometry input by behavior_path_planner |
| map | `vector_map` | Monitored as vector map input by behavior_path_planner |
| perception | `traffic_signals` | Monitored as traffic signal input by behavior_path_planner |
| perception | `objects` | Monitored as perception objects input by behavior_path_planner |
| perception | `pointcloud` | Monitored as obstacle segmentation input by behavior_path_planner |
| planning | `route` | Monitored as route input by behavior_path_planner |

A new diagnostic entry `/planning/021-incoming-message-timeout` is added to `planning.yaml`, which aggregates the `behavior_path_planner`'s `incoming_message_timeout` diagnostics.

## How was this PR tested?

Build and Launch scenario simulator on your local machine.

```bash
cd /path/to/autoware/src/autoware/launcher
gh pr checkout 1316 --repo tier4/autoware_launch

cd /path/to/autoware
vcs import src <  simulator.repos
vcs import src < tools.repos
colcon build --symlink-install --cmake-args -DCMAKE_BUILD_TYPE=Release -DCMAKE_CXX_FLAGS="-w" -DBUILD_TESTING=false

# メタリポジトリで以下を実行する
webauto ci scenario run --project-id autoware_dev --scenario-id c68325cb-cd82-493c-a5fa-658912b53304 --scenario-version-id 2 --scenario-parameters '__tier4_modifier_ego_speed=11.1111,__tier4_modifier_max_stand_still=100' --simulation-name planning_sim_v2
```

```bash
 ros2 run autoware_diagnostic_graph_utils converter_node
```

```bash
 ros2 run rqt_runtime_monitor rqt_runtime_monitor --ros-args -r diagnostics:=diagnostics_array
```

<img width="1089" height="264" alt="image" src="https://github.com/user-attachments/assets/56147ece-e31c-4b85-9129-261d683c5c73" />



## Notes for reviewers

- This PR depends on autowarefoundation/autoware_universe#12075 being merged and available.
- The `dummy_diag_publisher.param.yaml` is also updated to remove corresponding required diag entries that no longer exist.
- `autoware-carla.yaml` is updated to remove the route `topic_state_monitor` reference from the planning section.

Evaluator worked fine after merging this change.
https://evaluation.tier4.jp/evaluation/reports/5161127c-d630-578d-b6f3-c365a232930e/?project_id=autoware_dev

## Effects on system behavior

- **No functional regression**: The topics previously monitored externally by `topic_state_monitor` are now monitored internally by `behavior_path_planner` via its `incoming_message_timeout` feature. Diagnostic errors for these topics will still be reported via `/diagnostics`.
- **Diagnostic path change**: The error condition for these topics is now aggregated under `/planning/021-incoming-message-timeout` instead of individual `/localization/001-*`, `/map/001-*`, `/perception/001-*`, and `/planning/001-*/route` paths.

