### PR TITLE
fix(imu_scale_bias_estimator): ekf initializes only when it has in bounds samples (#1315)

### DIFF
--- a/aip_launcher/aip_xx1_launch/config/gyro_scale_estimator.param.yaml
+++ b/aip_launcher/aip_xx1_launch/config/gyro_scale_estimator.param.yaml
@@ -29,6 +29,8 @@
       measurement_noise_r_angle: 0.00005
       min_covariance_angle: 1e-11
       decay_coefficient: 0.99999998
+      samples_in_bounds_to_init: 250
+      max_reinitialization_retries: 5
 
     scale_imu_injection:
       modify_imu_scale: false


### PR DESCRIPTION
## Description
Pick following PR
https://github.com/autowarefoundation/autoware_universe/pull/11816/changes#diff-ee03f6c96c90d14862137b142efca4978434dfcdda63c7054d9e3f49b3a03eafR32

Cherry-pick 
https://github.com/tier4/autoware_launch/pull/1315

## How was this PR tested?

## Notes for reviewers

None.

## Effects on system behavior

None.
