### PR TITLE
feat(behavior_path_planner): add launch configurations for direction_change_module

### DIFF
--- a/autoware_launch/config/planning/preset/default_preset.yaml
+++ b/autoware_launch/config/planning/preset/default_preset.yaml
@@ -44,7 +44,7 @@ launch:
       default: "true"
   - arg:
       name: launch_direction_change_module
-      default: "true"
+      default: "false"
 
   # behavior velocity modules
   - arg:

--- a/autoware_launch/config/planning/preset/default_preset.yaml
+++ b/autoware_launch/config/planning/preset/default_preset.yaml
@@ -42,6 +42,9 @@ launch:
   - arg:
       name: launch_bidirectional_traffic_module
       default: "true"
+  - arg:
+      name: launch_direction_change_module
+      default: "true"
 
   # behavior velocity modules
   - arg:

--- a/autoware_launch/config/planning/scenario_planning/lane_driving/behavior_planning/behavior_path_planner/scene_module_manager.param.yaml
+++ b/autoware_launch/config/planning/scenario_planning/lane_driving/behavior_planning/behavior_path_planner/scene_module_manager.param.yaml
@@ -21,6 +21,7 @@
       - "external_request_lane_change_left"
       - "external_request_lane_change_right"
       - "bidirectional_traffic"
+      - "direction_change"
     slot3:
       - "goal_planner"
     slot4:
@@ -83,6 +84,11 @@
       enable_simultaneous_execution_as_candidate_module: false
 
     bidirectional_traffic:
+      enable_rtc: false
+      enable_simultaneous_execution_as_approved_module: true
+      enable_simultaneous_execution_as_candidate_module: true
+
+    direction_change:
       enable_rtc: false
       enable_simultaneous_execution_as_approved_module: true
       enable_simultaneous_execution_as_candidate_module: true

--- a/autoware_launch/config/planning/scenario_planning/lane_driving/behavior_planning/behavior_path_planner/scene_module_manager.param.yaml
+++ b/autoware_launch/config/planning/scenario_planning/lane_driving/behavior_planning/behavior_path_planner/scene_module_manager.param.yaml
@@ -90,5 +90,5 @@
 
     direction_change:
       enable_rtc: false
-      enable_simultaneous_execution_as_approved_module: true
+      enable_simultaneous_execution_as_approved_module: false
       enable_simultaneous_execution_as_candidate_module: true

--- a/autoware_launch/config/planning/scenario_planning/lane_driving/behavior_planning/behavior_path_planner/scene_module_manager.param.yaml
+++ b/autoware_launch/config/planning/scenario_planning/lane_driving/behavior_planning/behavior_path_planner/scene_module_manager.param.yaml
@@ -91,4 +91,4 @@
     direction_change:
       enable_rtc: false
       enable_simultaneous_execution_as_approved_module: false
-      enable_simultaneous_execution_as_candidate_module: true
+      enable_simultaneous_execution_as_candidate_module: false

--- a/autoware_launch/launch/components/tier4_planning_component.launch.xml
+++ b/autoware_launch/launch/components/tier4_planning_component.launch.xml
@@ -82,6 +82,7 @@
       <arg name="behavior_path_planner_start_planner_module_param_path" value="$(var behavior_path_config_path)/start_planner/start_planner.param.yaml"/>
       <arg name="behavior_path_bidirectional_traffic_module_param_path" value="$(var behavior_path_config_path)/autoware_behavior_path_bidirectional_traffic_module/bidirectional_traffic.param.yaml"/>
       <arg name="behavior_path_planner_drivable_area_expansion_param_path" value="$(var behavior_path_config_path)/drivable_area_expansion.param.yaml"/>
+      <arg name="behavior_path_planner_direction_change_module_param_path" value="$(find-pkg-share autoware_behavior_path_direction_change_module)/config/direction_change.param.yaml"/>
 
       <!-- path generator -->
       <arg name="path_generator_param_path" value="$(find-pkg-share autoware_launch)/config/planning/scenario_planning/lane_driving/behavior_planning/path_generator/path_generator.param.yaml"/>

--- a/autoware_launch/package.xml
+++ b/autoware_launch/package.xml
@@ -12,6 +12,7 @@
   <buildtool_depend>ament_cmake_auto</buildtool_depend>
 
   <exec_depend>autoware_adapi_adaptors</exec_depend>
+  <exec_depend>autoware_behavior_path_direction_change_module</exec_depend>
   <exec_depend>autoware_carla_interface</exec_depend>
   <exec_depend>autoware_diagnostic_graph_aggregator</exec_depend>
   <exec_depend>autoware_diagnostic_graph_utils</exec_depend>

--- a/tier4_universe_launch/tier4_planning_launch/launch/scenario_planning/lane_driving/behavior_planning/behavior_planning.launch.xml
+++ b/tier4_universe_launch/tier4_planning_launch/launch/scenario_planning/lane_driving/behavior_planning/behavior_planning.launch.xml
@@ -22,6 +22,7 @@
   <arg name="launch_sampling_planner_module" default="true"/>
   <arg name="launch_side_shift_module" default="true"/>
   <arg name="launch_bidirectional_traffic_module" default="true"/>
+  <arg name="launch_direction_change_module" default="false"/>
 
   <arg name="launch_crosswalk_module" default="true"/>
   <arg name="launch_walkway_module" default="true"/>
@@ -61,6 +62,11 @@
     name="behavior_path_planner_launch_modules"
     value="$(eval &quot;'$(var behavior_path_planner_launch_modules)' + 'autoware::behavior_path_planner::BidirectionalTrafficModuleManager, '&quot;)"
     if="$(var launch_bidirectional_traffic_module)"
+  />
+  <let
+    name="behavior_path_planner_launch_modules"
+    value="$(eval &quot;'$(var behavior_path_planner_launch_modules)' + 'autoware::behavior_path_planner::DirectionChangeModuleManager, '&quot;)"
+    if="$(var launch_direction_change_module)"
   />
   <let
     name="behavior_path_planner_launch_modules"
@@ -255,6 +261,7 @@
         <param from="$(var behavior_path_planner_static_obstacle_avoidance_module_param_path)"/>
         <param from="$(var behavior_path_planner_avoidance_by_lc_module_param_path)"/>
         <param from="$(var behavior_path_bidirectional_traffic_module_param_path)"/>
+        <param from="$(var behavior_path_planner_direction_change_module_param_path)"/>
         <param from="$(var behavior_path_planner_dynamic_obstacle_avoidance_module_param_path)"/>
         <param from="$(var behavior_path_planner_lane_change_module_param_path)"/>
         <param from="$(var behavior_path_planner_goal_planner_module_param_path)"/>


### PR DESCRIPTION
## Description
This PR adds the launch configuration required to enable the `direction_change_module`, newly developed for reverse and Kturns in narrow spaces.
For this PR, the `direction_change_module` is a prototype version, so we will set it to be disabled by default.
If you would like to enable it, please set the following three parameters to `true`.

- **autoware_launch/config/planning/preset/default_preset.yaml**
　arg: name: launch_direction_change_module  default: "`false`"

- **autoware_launch/config/planning/scenario_planning/lane_driving/behavior_planning/behavior_path_planner/scene_module_manager.param.yaml**
　enable_simultaneous_execution_as_approved_module: `false`
　enable_simultaneous_execution_as_candidate_module: `false`
- **tier4_universe_launch/tier4_planning_launch/launch/scenario_planning/lane_driving/behavior_planning/behavior_planning.launch.xml**
　arg name="launch_direction_change_module" default="`false`"/

Please look [tier4/autoware_universe#2728](https://github.com/tier4/autoware_universe/pull/2728)

## How was this PR tested?
Please look [tier4/autoware_universe#2728](https://github.com/tier4/autoware_universe/pull/2728)

## Notes for reviewers
This should be merged along with [tier4/autoware_universe#2728](https://github.com/tier4/autoware_universe/pull/2728)

## Effects on system behavior

Please look [tier4/autoware_universe#2728](https://github.com/tier4/autoware_universe/pull/2728)
