### PR TITLE
ci: add sync-upstream-awf to provide auto-merged staging branch

### DIFF
--- a/.github/workflows/sync-upstream-awf.yaml
+++ b/.github/workflows/sync-upstream-awf.yaml
@@ -46,6 +46,7 @@ jobs:
           if git merge --no-edit awf/main; then
             echo "✅ No conflicts detected. staging branch is updated with awf/main."
 
+            git fetch origin
             if git rev-parse --verify origin/staging >/dev/null 2>&1 && git diff --quiet origin/staging; then
                 echo "No changes to push to staging branch."
             else
@@ -67,7 +68,7 @@ jobs:
 
   comment-for-conflicts:
     needs: [try-update-staging, sync-upstream-batch]
-    if: ${{ always() }}
+    if: ${{ always() && github.repository == 'tier4/autoware_launch' }}
     runs-on: ubuntu-latest
     steps:
       - name: Generate token

--- a/.github/workflows/sync-upstream-awf.yaml
+++ b/.github/workflows/sync-upstream-awf.yaml
@@ -83,7 +83,7 @@ jobs:
           GH_TOKEN: ${{ steps.generate-token.outputs.token }}
         run: |
           # Search for open PRs with the specific branch name
-          PR_NUMBER=$(gh pr list --repo "${{ github.repository }}" --state open --head "sync_tier4_main_from_awf_main" --json number --jq '.[0].number')
+          PR_NUMBER=$(gh pr list --repo "${{ github.repository }}" --state open --head "sync_tier4_main_from_awf_main" --json number --jq '.[0].number // empty')
 
           if [ -z "$PR_NUMBER" ]; then
             echo "Error: No open PR found with head branch sync_tier4_main_from_awf_main"

--- a/.github/workflows/sync-upstream-awf.yaml
+++ b/.github/workflows/sync-upstream-awf.yaml
@@ -5,6 +5,10 @@ on:
   schedule:
     - cron: 0 */1 * * * # every 1 hour (**:00)
 
+concurrency:
+  group: ${{ github.workflow }}-${{ github.event_name }}-${{ github.ref }}
+  cancel-in-progress: true
+
 jobs:
   try-update-staging:
     runs-on: ubuntu-latest

--- a/.github/workflows/sync-upstream-awf.yaml
+++ b/.github/workflows/sync-upstream-awf.yaml
@@ -6,7 +6,7 @@ on:
     - cron: 0 */1 * * * # every 1 hour (**:00)
 
 concurrency:
-  group: ${{ github.workflow }}-${{ github.event_name }}-${{ github.ref }}
+  group: sync-upstream-awf-staging
   cancel-in-progress: true
 
 jobs:
@@ -87,8 +87,8 @@ jobs:
           PR_NUMBER=$(gh pr list --repo "${{ github.repository }}" --state open --head "sync_tier4_main_from_awf_main" --json number --jq '.[0].number // empty')
 
           if [ -z "$PR_NUMBER" ]; then
-            echo "Error: No open PR found with head branch sync_tier4_main_from_awf_main"
-            exit 1
+            echo "No open PR found with head branch sync_tier4_main_from_awf_main. Skipping comment update."
+            exit 0
           fi
 
           echo "Found PR #$PR_NUMBER for branch sync_tier4_main_from_awf_main"

--- a/.github/workflows/sync-upstream-awf.yaml
+++ b/.github/workflows/sync-upstream-awf.yaml
@@ -16,6 +16,7 @@ jobs:
         uses: actions/checkout@v4
         with:
           ref: tier4/main
+          fetch-depth: 0
 
       - name: Generate token
         id: generate-token
@@ -39,8 +40,15 @@ jobs:
 
           # Try to merge upstream branch
           if git merge --no-edit awf/main; then
-            echo "✅ No conflicts detected. Pushing directly to staging branch"
-            git push origin staging --force
+            echo "✅ No conflicts detected. staging branch is updated with awf/main."
+
+            if git rev-parse --verify origin/staging >/dev/null 2>&1 && git diff --quiet origin/staging; then
+                echo "No changes to push to staging branch."
+            else
+                echo "Pushing updated staging branch to origin..."
+                git push origin staging --force
+            fi
+
             echo "had-conflicts=false" >> "$GITHUB_OUTPUT"
           else
             echo "⚠️ Conflicts detected. Not pushing to staging branch."
@@ -55,6 +63,7 @@ jobs:
 
   comment-for-conflicts:
     needs: [try-update-staging, sync-upstream-batch]
+    if: ${{ always() }}
     runs-on: ubuntu-latest
     steps:
       - name: Generate token
@@ -66,6 +75,8 @@ jobs:
 
       - name: Find issue number for PR branch sync_tier4_main_from_awf_main
         id: find-issue
+        env:
+          GH_TOKEN: ${{ steps.generate-token.outputs.token }}
         run: |
           # Search for open PRs with the specific branch name
           PR_NUMBER=$(gh pr list --repo "${{ github.repository }}" --state open --head "sync_tier4_main_from_awf_main" --json number --jq '.[0].number')
@@ -86,7 +97,7 @@ jobs:
           issue-number: ${{ steps.find-issue.outputs.issue_number }}
           body-includes: "## AWF Conflict Detection Result"
 
-      - name: Comment on PR about conflicts
+      - name: Update the conflict comment on PR about conflicts
         uses: peter-evans/create-or-update-comment@v3
         if: ${{ needs.try-update-staging.outputs.had-conflicts == 'true' }}
         with:
@@ -98,7 +109,7 @@ jobs:
 
             ⚠️ The automatic sync from AWF's main branch to tier4/main branch encountered conflicts. Please resolve the conflicts manually and merge this PR.
 
-      - name: Remove the conflict comment on PR if conflicts are resolved
+      - name: Update the conflict comment on PR if conflicts are resolved
         uses: peter-evans/create-or-update-comment@v3
         if: ${{ needs.try-update-staging.outputs.had-conflicts == 'false' }}
         with:

--- a/.github/workflows/sync-upstream-awf.yaml
+++ b/.github/workflows/sync-upstream-awf.yaml
@@ -88,6 +88,7 @@ jobs:
 
           if [ -z "$PR_NUMBER" ]; then
             echo "No open PR found with head branch sync_tier4_main_from_awf_main. Skipping comment update."
+            echo "issue_number=" >> "$GITHUB_OUTPUT"
             exit 0
           fi
 
@@ -96,6 +97,7 @@ jobs:
 
       - name: Find Conflict Warning Comment
         uses: peter-evans/find-comment@v2
+        if: ${{ steps.find-issue.outputs.issue_number != '' }}
         id: find-comment
         with:
           token: ${{ steps.generate-token.outputs.token }}
@@ -104,7 +106,7 @@ jobs:
 
       - name: Update the conflict comment on PR about conflicts
         uses: peter-evans/create-or-update-comment@v3
-        if: ${{ needs.try-update-staging.outputs.had-conflicts == 'true' }}
+        if: ${{ needs.try-update-staging.outputs.had-conflicts == 'true' && steps.find-issue.outputs.issue_number != '' }}
         with:
           token: ${{ steps.generate-token.outputs.token }}
           issue-number: ${{ steps.find-issue.outputs.issue_number }}
@@ -116,7 +118,7 @@ jobs:
 
       - name: Update the conflict comment on PR if conflicts are resolved
         uses: peter-evans/create-or-update-comment@v3
-        if: ${{ needs.try-update-staging.outputs.had-conflicts == 'false' }}
+        if: ${{ needs.try-update-staging.outputs.had-conflicts == 'false' && steps.find-issue.outputs.issue_number != '' }}
         with:
           token: ${{ steps.generate-token.outputs.token }}
           issue-number: ${{ steps.find-issue.outputs.issue_number }}

--- a/.github/workflows/sync-upstream-awf.yaml
+++ b/.github/workflows/sync-upstream-awf.yaml
@@ -1,0 +1,111 @@
+name: sync-upstream-awf
+
+on:
+  workflow_dispatch:
+  schedule:
+    - cron: 0 */1 * * * # every 1 hour (**:00)
+
+jobs:
+  try-update-staging:
+    runs-on: ubuntu-latest
+    if: ${{ github.repository == 'tier4/autoware_launch' }}
+    outputs:
+      had-conflicts: ${{ steps.check-conflicts.outputs.had-conflicts }}
+    steps:
+      - name: Checkout repository
+        uses: actions/checkout@v4
+        with:
+          ref: tier4/main
+
+      - name: Generate token
+        id: generate-token
+        uses: tibdex/github-app-token@v2
+        with:
+          app_id: ${{ secrets.APP_ID }}
+          private_key: ${{ secrets.PRIVATE_KEY }}
+
+      - name: Set git config
+        uses: autowarefoundation/autoware-github-actions/set-git-config@v1
+        with:
+          token: ${{ steps.generate-token.outputs.token }}
+
+      - name: Check for conflicts
+        id: check-conflicts
+        run: |
+          git checkout -B staging
+
+          git remote add awf https://github.com/autowarefoundation/autoware_launch
+          git fetch awf main
+
+          # Try to merge upstream branch
+          if git merge --no-edit awf/main; then
+            echo "✅ No conflicts detected. Pushing directly to staging branch"
+            git push origin staging --force
+            echo "had-conflicts=false" >> "$GITHUB_OUTPUT"
+          else
+            echo "⚠️ Conflicts detected. Not pushing to staging branch."
+            git merge --abort
+            echo "had-conflicts=true" >> "$GITHUB_OUTPUT"
+          fi
+
+  sync-upstream-batch:
+    needs: try-update-staging
+    uses: ./.github/workflows/sync-upstream-batch.yaml
+    secrets: inherit
+
+  comment-for-conflicts:
+    needs: [try-update-staging, sync-upstream-batch]
+    runs-on: ubuntu-latest
+    steps:
+      - name: Generate token
+        id: generate-token
+        uses: tibdex/github-app-token@v2
+        with:
+          app_id: ${{ secrets.APP_ID }}
+          private_key: ${{ secrets.PRIVATE_KEY }}
+
+      - name: Find issue number for PR branch sync_tier4_main_from_awf_main
+        id: find-issue
+        run: |
+          # Search for open PRs with the specific branch name
+          PR_NUMBER=$(gh pr list --repo "${{ github.repository }}" --state open --head "sync_tier4_main_from_awf_main" --json number --jq '.[0].number')
+
+          if [ -z "$PR_NUMBER" ]; then
+            echo "Error: No open PR found with head branch sync_tier4_main_from_awf_main"
+            exit 1
+          fi
+
+          echo "Found PR #$PR_NUMBER for branch sync_tier4_main_from_awf_main"
+          echo "issue_number=$PR_NUMBER" >> "$GITHUB_OUTPUT"
+
+      - name: Find Conflict Warning Comment
+        uses: peter-evans/find-comment@v2
+        id: find-comment
+        with:
+          token: ${{ steps.generate-token.outputs.token }}
+          issue-number: ${{ steps.find-issue.outputs.issue_number }}
+          body-includes: "## AWF Conflict Detection Result"
+
+      - name: Comment on PR about conflicts
+        uses: peter-evans/create-or-update-comment@v3
+        if: ${{ needs.try-update-staging.outputs.had-conflicts == 'true' }}
+        with:
+          token: ${{ steps.generate-token.outputs.token }}
+          issue-number: ${{ steps.find-issue.outputs.issue_number }}
+          comment-id: ${{ steps.find-comment.outputs.comment_id }}
+          body: |
+            ## AWF Conflict Detection Result
+
+            ⚠️ The automatic sync from AWF's main branch to tier4/main branch encountered conflicts. Please resolve the conflicts manually and merge this PR.
+
+      - name: Remove the conflict comment on PR if conflicts are resolved
+        uses: peter-evans/create-or-update-comment@v3
+        if: ${{ needs.try-update-staging.outputs.had-conflicts == 'false' }}
+        with:
+          token: ${{ steps.generate-token.outputs.token }}
+          issue-number: ${{ steps.find-issue.outputs.issue_number }}
+          comment-id: ${{ steps.find-comment.outputs.comment_id }}
+          body: |
+            ## AWF Conflict Detection Result
+
+            ✅ The automatic sync from AWF's main branch to tier4/main branch did not encounter any conflicts and reflected in staging branch. Review carefully for tier4 specific adjustments before merging.


### PR DESCRIPTION
## Description

[Slack thread](https://star4.slack.com/archives/C07FJ32G6JU/p1772095109038869)

Instead of #1319 which tries to automerge into main branch without any review, this PR aims to:
* have `staging` branch which has the latest tier4/main + AWF main in most cases, to implement "testing with the latest AWF" in the current situation
* keep `tier4/main` to be manually reviewed and merged to guarantee one more check for consistency
* Does not modify the universal syncing mechanism which are reused in downstream products

If auto-merge fails, then `staging` does not update, and the syncing PR (from awf main to tier4/main) has a comment that a conflict has been detected.

A long-term solution might be: completely own tier4/autoware_launch, not sync from AWF.

## How was this PR tested?

## Notes for reviewers

We will also have a test-only branch in pilot-auto repository, which tracks the latest main, but the branch for autoware_launch is staging, not tier4/main.
The daily checks for pilot-auto should be done against this test-only branch, not main.

## Effects on system behavior

None.
