### PR TITLE
feat: add_trajectory_deviation_check to MRM

### DIFF
--- a/autoware_launch/config/system/tier4_diagnostics/control.yaml
+++ b/autoware_launch/config/system/tier4_diagnostics/control.yaml
@@ -25,6 +25,7 @@ units:
     list:
       - { type: link, link: /control/001-topic_status/control_command-error }
       - { type: link, link: /control/004-lane_departure-error }
+      - { type: link, link: /control/005-lane_departure-error }
       - { type: link, link: /control/009-aeb_emergency_stop }
       # - { type: link, link: /control/010-max_distance_deviation-error }
       # - { type: link, link: /control/011-slip_detection }
@@ -62,6 +63,12 @@ units:
       type: link
       link: /control/004-lane_departure
 
+  - path: /control/005-lane_departure-error
+    type: warn-to-ok
+    item:
+      type: link
+      link: /control/005-trajectory_deviation
+
   - path: /control/010-max_distance_deviation-error
     type: warn-to-ok
     item:
@@ -90,6 +97,12 @@ units:
     type: diag
     node: lane_departure_checker_node
     name: lane_departure
+    timeout: 1.0
+
+  - path: /control/005-trajectory_deviation
+    type: diag
+    node: lane_departure_checker_node
+    name: trajectory_deviation
     timeout: 1.0
 
   - path: /control/007-external_command_converter_heartbeat


### PR DESCRIPTION
## Description
With the current MRM configuration, the system could continue automatic driving even when the planned trajectory and ego vehicle position were largely deviated, without triggering MRM, which posed a significant safety risk of resulting in sudden steering. Therefore, the system has been configured so that MRM is triggered unless the planned trajectory and ego vehicle position remain within a certain distance.

## How was this PR tested?
(TIER IV Internal Link)
■Evaluator
 Before: https://evaluation.tier4.jp/evaluation/reports/7608dbe9-7d2c-50b6-a496-e9971268a4b4?project_id=autoware_dev
After: https://evaluation.tier4.jp/evaluation/reports/2a696169-f762-5179-9b67-758f20b3a137?project_id=autoware_dev

(TODO)
## Notes for reviewers

None.

## Effects on system behavior
- Before: Automatic driving could continue even when the ego vehicle
  position deviated significantly from the planned trajectory. In such
  cases, the system did not enter MRM and attempted to follow the
  plan, which could lead to sudden steering and increased safety risk.

- After: When the lateral (and/or longitudinal) deviation between the
  planned trajectory and the ego vehicle position exceeds a configured
  threshold, MRM is triggered. The system no longer continues
  automatic driving in a largely deviated state, reducing the risk of
  sudden steering and improving safety.
