### PR TITLE
refactor(tier4_diagnostics): replace topic-state-error by controller

### DIFF
--- a/autoware_launch/config/system/tier4_diagnostics/autoware-carla.yaml
+++ b/autoware_launch/config/system/tier4_diagnostics/autoware-carla.yaml
@@ -130,17 +130,11 @@ units:
       - type: and
         list:
           - { type: link, link: /autoware/planning/topic_rate_check/route }
-          - { type: link, link: /autoware/planning/topic_rate_check/trajectory }
           - { type: link, link: /autoware/planning/trajectory_validation }
 
   - path: /autoware/planning/topic_rate_check/route
     type: diag
     node: topic_state_monitor_mission_planning_route
-    name: planning_topic_status
-
-  - path: /autoware/planning/topic_rate_check/trajectory
-    type: diag
-    node: topic_state_monitor_scenario_planning_trajectory
     name: planning_topic_status
 
   - path: /autoware/planning/trajectory_validation

--- a/autoware_launch/config/system/tier4_diagnostics/control.yaml
+++ b/autoware_launch/config/system/tier4_diagnostics/control.yaml
@@ -28,6 +28,7 @@ units:
       - { type: link, link: /control/009-aeb_emergency_stop }
       # - { type: link, link: /control/010-max_distance_deviation-error }
       # - { type: link, link: /control/011-slip_detection }
+      - { type: link, link: /control/012-incoming_message_timeout }
       - { type: link, link: /control/collision_detector }
       # - { type: link, link: /control/acceleration_error }
       - { type: link, link: /control/rolling_back }
@@ -121,6 +122,12 @@ units:
     node: slip_detector
     name: slip_status
     timeout: 3.0
+
+  - path: /control/012-incoming_message_timeout
+    type: diag
+    node: controller_node_exe
+    name: incoming_message_timeout
+    timeout: 1.0
 
   - path: /control/collision_detector
     type: diag

--- a/autoware_launch/config/system/tier4_diagnostics/planning.yaml
+++ b/autoware_launch/config/system/tier4_diagnostics/planning.yaml
@@ -25,7 +25,6 @@ units:
     list:
       - { type: link, link: /planning/000-component_status/route_state }
       - { type: link, link: /planning/001-topic_status/route-error }
-      - { type: link, link: /planning/001-topic_status/trajectory-error }
       - { type: link, link: /planning/003-trajectory_finite_validation-error }
       - { type: link, link: /planning/004-trajectory_interval_validation-error }
       - { type: link, link: /planning/005-trajectory_curvature_validation-error }
@@ -65,12 +64,6 @@ units:
     item:
       type: link
       link: /planning/001-topic_status/route
-
-  - path: /planning/001-topic_status/trajectory-error
-    type: warn-to-ok
-    item:
-      type: link
-      link: /planning/001-topic_status/trajectory
 
   - path: /planning/003-trajectory_finite_validation-error
     type: warn-to-ok
@@ -183,12 +176,6 @@ units:
   - path: /planning/001-topic_status/route
     type: diag
     node: topic_state_monitor_mission_planning_route
-    name: planning_topic_status
-    timeout: 1.0
-
-  - path: /planning/001-topic_status/trajectory
-    type: diag
-    node: topic_state_monitor_scenario_planning_trajectory
     name: planning_topic_status
     timeout: 1.0
 


### PR DESCRIPTION
## Description

Remove `topic_state_monitor`-based diagnostic entries that are now redundant, because `trajectory_follower_node` internally monitors its input message timeouts (see autowarefoundation/autoware_universe#12082).

The following `topic_state_monitor` entries are removed from `tier4_diagnostics` config:

| Domain | Removed topic_state_monitor | Reason |
|---|---|---|
| planning | `trajectory` | Monitored as trajectory input by trajectory_follower_node |

A new diagnostic entry `/control/012-incoming_message_timeout` is added to `control.yaml`, which aggregates the `trajectory_follower_node`'s `incoming_message_timeout` diagnostics.

## How was this PR tested?

Build and Launch planning simulator on your local machine.

```bash
cd /path/to/autoware/src/autoware/launcher
gh pr checkout 1316 --repo tier4/autoware_launch

ros2 launch autoware_launch planning_simulator.launch.xml map_path:=$HOME/autoware_map/sample-map-planning/ vehicle_model:=sample_vehicle sensor_model:=awsim_sensor_kit

```

```bash
 ros2 run autoware_diagnostic_graph_utils converter_node
```

```bash
 ros2 run rqt_runtime_monitor rqt_runtime_monitor --ros-args -r diagnostics:=diagnostics_array
```

You'll find that `/control/012-incoming_message_timeout` is `ok` after route is given.
<img width="1290" height="523" alt="image" src="https://github.com/user-attachments/assets/7d33f7df-46ed-45eb-b0ae-5ee7bd609fdf" />



## Notes for reviewers


- `autoware-carla.yaml` is updated to remove the trajectory `topic_state_monitor` reference from the planning section.

Evaluator worked fine after merging this change.
https://evaluation.tier4.jp/evaluation/reports/f4b62541-3aef-5f8f-a3c0-824090a5d513?project_id=autoware_dev

## Effects on system behavior

- **No functional regression**: The topics previously monitored externally by `topic_state_monitor` are now monitored internally by `trajectory_follower` via its `incoming_message_timeout` feature. Diagnostic errors for these topics will still be reported via `/diagnostics`.
- **Diagnostic path change**: The error condition for these topics is now aggregated under `/control/012-incoming_message_timeout` instead of individual path.

