### PR TITLE
fix(`default_adapi`): missing diag timeout parameters

### DIFF
--- a/autoware_launch/config/system/default_adapi/default_adapi.param.yaml
+++ b/autoware_launch/config/system/default_adapi/default_adapi.param.yaml
@@ -29,10 +29,14 @@
 /adapi/node/manual/local:
   ros__parameters:
     mode: local
+    diag_timeout_warn_duration: 1.0
+    diag_timeout_error_duration: 2.0
 
 /adapi/node/manual/remote:
   ros__parameters:
     mode: remote
+    diag_timeout_warn_duration: 1.0
+    diag_timeout_error_duration: 2.0
 
 /adapi/node/fail_safe:
   ros__parameters:


### PR DESCRIPTION
## Description

Bug fix PR: This PR addresses the issue of missing diagnostic timeout parameters in the default ADAPI configuration, which are added by [this PR](https://github.com/autowarefoundation/autoware_universe/pull/11554). By adding these parameters, we can launch the system without errors and ensure that the diagnostic timeout functionality works as intended.

## Related links

- https://github.com/autowarefoundation/autoware_universe/pull/11554

## How was this PR tested?

- I will check if the launch succeeds with this PR. Give me time for the tests.
→ I verified at least planning simulation worked as follows with this PR.
```bash
ros2 launch autoware_launch planning_simulator.launch.xml map_path:=$HOME/autoware_map/sample-map-planning vehicle_model:=sample_vehicle sensor_model:=sample_sensor_kit
```
- Initialize position
- Set the goal
- Drive with autonomous mode

## Notes for reviewers

- Adds missing diagnostic timeout parameters to the default ADAPI configuration.

## Interface changes

- None

<!-- ⬇️🔴

### Topic changes

#### Additions and removals

| Change type   | Topic Type      | Topic Name    | Message Type        | Description       |
|:--------------|:----------------|:--------------|:--------------------|:------------------|
| Added/Removed | Pub/Sub/Srv/Cli | `/topic_name` | `std_msgs/String`   | Topic description |

#### Modifications

| Version | Topic Type      | Topic Name        | Message Type        | Description       |
|:--------|:----------------|:------------------|:--------------------|:------------------|
| Old     | Pub/Sub/Srv/Cli | `/old_topic_name` | `sensor_msgs/Image` | Topic description |
| New     | Pub/Sub/Srv/Cli | `/new_topic_name` | `sensor_msgs/Image` | Topic description |

### ROS Parameter Changes

#### Additions and removals

| Change type   | Parameter Name | Type     | Default Value | Description       |
|:--------------|:---------------|:---------|:--------------|:------------------|
| Added/Removed | `param_name`   | `double` | `1.0`         | Param description |

#### Modifications

| Version | Parameter Name   | Type     | Default Value | Description       |
|:--------|:-----------------|:---------|:--------------|:------------------|
| Old     | `old_param_name` | `double` | `1.0`         | Param description |
| New     | `new_param_name` | `double` | `1.0`         | Param description |

🔴⬆️ -->

## Effects on system behavior

- Allows launching without errors; diagnostic timeout behavior matches expected defaults.
