### PR TITLE
chore: remove v2x for vanilla

### DIFF
--- a/autoware_launch/launch/autoware.launch.xml
+++ b/autoware_launch/launch/autoware.launch.xml
@@ -6,7 +6,6 @@
   <arg name="sensor_model" default="sample_sensor_kit" description="sensor model name"/>
   <arg name="pointcloud_container_name" default="pointcloud_container"/>
   <arg name="data_path" default="$(env HOME)/autoware_data" description="packages data and artifacts directory path"/>
-  <arg name="v2x_location" default="invalid_location" description="location for v2x (e.g. komatsu, shiojiri)"/>
 
   <!-- launch module preset -->
   <arg name="planning_setting" default="rule_based" description="planning setting diffusion_planner / rule_based"/>
@@ -25,7 +24,6 @@
   <arg name="launch_planning" default="true" description="launch planning"/>
   <arg name="launch_control" default="true" description="launch control"/>
   <arg name="launch_api" default="true" description="launch api"/>
-  <arg name="launch_v2x" default="true" description="launch V2X"/>
   <!-- Global parameters -->
   <arg name="use_sim_time" default="false" description="use_sim_time"/>
   <!-- Vehicle -->
@@ -141,15 +139,6 @@
     <include file="$(find-pkg-share autoware_launch)/launch/components/tier4_autoware_api_component.launch.xml">
       <arg name="use_sim_time" value="$(var use_sim_time)"/>
       <arg name="vehicle_model" value="$(var vehicle_model)"/>
-    </include>
-  </group>
-
-  <!-- V2X -->
-  <group if="$(var launch_v2x)">
-    <include file="$(find-pkg-share traffic_signal_launcher)/launch/traffic_signal.launch.xml">
-      <arg name="map_path" value="$(var map_path)"/>
-      <arg name="vehicle_model" value="$(var vehicle_model)"/>
-      <arg name="location" value="$(var v2x_location)"/>
     </include>
   </group>
 

--- a/autoware_launch/package.xml
+++ b/autoware_launch/package.xml
@@ -36,7 +36,6 @@
   <exec_depend>tier4_simulator_launch</exec_depend>
   <exec_depend>tier4_system_launch</exec_depend>
   <exec_depend>tier4_vehicle_launch</exec_depend>
-  <exec_depend>traffic_signal_launcher</exec_depend>
 
   <test_depend>ament_lint_auto</test_depend>
   <test_depend>autoware_lint_common</test_depend>


### PR DESCRIPTION
## Description

Remove v2x launch for vanilla, because of several reasons:
* v2x is TIER IV private package but the launcher system referring it is exposed to public.
* Not all downstream product is using v2x. v2x development / testing can be done in the product that uses it, not vanilla.

## How was this PR tested?

N/A (maybe we can run evaluator)

## Notes for reviewers

Downstream should be cautious - product using v2x should be careful not to remove v2x itself when merging this.

## Effects on system behavior

Removes unnecessary (ill-configured) v2x node from vanilla simulation.
