### PR TITLE
fix: let lane change died when we drive away from it manually (#1114) (#1224)

### DIFF
--- a/autoware_launch/config/planning/scenario_planning/lane_driving/behavior_planning/behavior_path_planner/lane_change/lane_change.param.yaml
+++ b/autoware_launch/config/planning/scenario_planning/lane_driving/behavior_planning/behavior_path_planner/lane_change/lane_change.param.yaml
@@ -151,6 +151,10 @@
         unsafe_hysteresis_threshold: 5      # [/]
         deceleration_sampling_num: 1        # [/] Used to sample the approved lane change path, specifically for checking safety against leading objects.
 
+      l2_overwrite:
+        enable: false
+        rewrite_overshoot_threshold: 5.0  # [m]
+
       lane_change_finish_judge_buffer: 2.0      # [m]
       finish_judge_lateral_threshold: 0.1        # [m]
       finish_judge_lateral_angle_deviation: 1.0 # [deg]


### PR DESCRIPTION
## Description
cherry-pick https://github.com/tier4/autoware_launch/pull/1114


## How was this PR tested?

## Notes for reviewers

This PR should be merged with https://github.com/tier4/autoware_universe/pull/2851

## Effects on system behavior

None.
