### PR TITLE
feat: update args for tier4 api v0.4.4

### DIFF
--- a/autoware_launch/launch/components/tier4_autoware_api_component.launch.xml
+++ b/autoware_launch/launch/components/tier4_autoware_api_component.launch.xml
@@ -9,10 +9,6 @@
   <arg name="rosbridge_enabled" default="true"/>
   <arg name="rosbridge_max_message_size" default="1000000000"/>
 
-  <!-- For API EOL information, see https://github.com/tier4/tier4_ad_api_adaptor -->
-  <!-- Pilot.Auto will continue to use 1 to align with Web.Auto release. -->
-  <arg name="api_mode" default="1" description="options: 0(All), 1(Without 2025/09 EOL API), 2(Without 2025/12 EOL API)"/>
-
   <!-- Global parameters -->
   <group scoped="false">
     <include file="$(find-pkg-share autoware_global_parameter_loader)/launch/global_params.launch.py">
@@ -24,9 +20,7 @@
   <!-- AD API -->
   <group>
     <include file="$(find-pkg-share tier4_autoware_api_launch)/launch/autoware_api.launch.xml">
-      <!-- The evaluation adapter is temporarily disabled because the interface name overlaps with TIER IV API.-->
-      <!-- <arg name="launch_evaluation_adapter" value="$(var scenario_simulation)"/> -->
-      <arg name="launch_evaluation_adapter" value="false"/>
+      <arg name="launch_evaluation_adapter" value="$(var scenario_simulation)"/>
       <arg name="default_adapi_param_path" value="$(find-pkg-share autoware_launch)/config/system/default_adapi/default_adapi.param.yaml"/>
     </include>
   </group>
@@ -34,7 +28,6 @@
   <!-- TIER IV -->
   <group if="$(var launch_tier4_api)">
     <include file="$(find-pkg-share tier4_autoware_api_extension_launch)/launch/tier4_autoware_api_extension.launch.xml">
-      <arg name="api_mode" value="$(var api_mode)"/>
       <arg name="rosbridge_enabled" value="$(var rosbridge_enabled)"/>
       <arg name="rosbridge_max_message_size" value="$(var rosbridge_max_message_size)"/>
     </include>


### PR DESCRIPTION
## Description

Update args for TIER IV Autoware API v0.4.4.
Related PR: https://github.com/tier4/tier4_ad_api_adaptor/pull/223

## How was this PR tested?

Planning Simulatorで自動走行できることを確認。

Evaluator
- https://evaluation.tier4.jp/evaluation/reports/8801c1f5-65d7-53a0-a361-91090fa132a0?project_id=autoware_dev
- https://evaluation.tier4.jp/evaluation/reports/82a48c8a-46a8-5e4c-b82e-0af2ba615ce0?project_id=autoware_dev
- https://evaluation.tier4.jp/evaluation/reports/f220acbe-c11d-52d1-9b19-9a65ab25abfe?project_id=autoware_dev

## Notes for reviewers

None.

## Effects on system behavior

None.
