### PR TITLE
fix(diffusion_planner): add missing parameter use_acados

### DIFF
--- a/autoware_launch/config/planning/neural_net_planner/trajectory_optimizer_plugins/trajectory_mpt_optimizer.param.yaml
+++ b/autoware_launch/config/planning/neural_net_planner/trajectory_optimizer_plugins/trajectory_mpt_optimizer.param.yaml
@@ -21,6 +21,8 @@
     # they represent clearance from the generated corridor bounds (simple perpendicular offsets),
     # NOT actual road boundaries or drivable area from maps.
     mpt:
+      use_acados: false
+      use_acados_circle_constraints: true
       option:
         steer_limit_constraint: false
         visualize_sampling_num: 1


### PR DESCRIPTION
## Description

Add missing parameter which fix the the following error

```
[autoware_trajectory_optimizer_node-25] [ERROR 1779948086.595090747] [planning.trajectory_generator.neural_network_based_planner.trajectory_optimizer_nodeinitialize]: MPT Optimizer plugin initialization FAILED: Statically typed parameter 'mpt.use_acados' must be initialized.
[autoware_trajectory_optimizer_node-25] [ERROR 1779948086.596053171] [planning.trajectory_generator.neural_network_based_planner.trajectory_optimizer_nodeload_plugin]: Unexpected error loading plugin 'autoware::trajectory_optimizer::plugin::TrajectoryMPTOptimizer': Statically typed parameter 'mpt.use_acados' must be initialized.
```

## How was this PR tested?

## Notes for reviewers

None.

## Effects on system behavior

None.
