### PR TITLE
fix(autoware_launch): rename exec_depend to autoware_trajectory_proce…

### DIFF
--- a/autoware_launch/package.xml
+++ b/autoware_launch/package.xml
@@ -20,7 +20,7 @@
   <exec_depend>autoware_dummy_infrastructure</exec_depend>
   <exec_depend>autoware_global_parameter_loader</exec_depend>
   <exec_depend>autoware_remaining_distance_time_calculator</exec_depend>
-  <exec_depend>autoware_trajectory_optimizer</exec_depend>
+  <exec_depend>autoware_trajectory_processor</exec_depend>
   <exec_depend>individual_params</exec_depend>
   <exec_depend>python3-bson</exec_depend>
   <exec_depend>python3-tornado</exec_depend>


### PR DESCRIPTION
Description
autoware_trajectory_optimizer was renamed to autoware_trajectory_processor in autoware_universe (autowarefoundation/autoware_universe#12954). The launch files were updated in autowarefoundation/autoware_launch#1908, but the <exec_depend> in autoware_launch/package.xml was missed — this line only exists in the tier4 fork (added in #1266), so the upstream rename PR could not update it.

As a result, rosdep install fails (both locally and in the webauto CI build):


ERROR: the following packages/stacks could not have their rosdep keys resolved to system dependencies:
autoware_launch: Cannot locate rosdep definition for [autoware_trajectory_optimizer]
Changes
Update the exec_depend to autoware_trajectory_processor.

Build : Local side is done